### PR TITLE
Clalancette/revamp time

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rcl_interfaces REQUIRED)
 find_package(rcljava_common REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
 
 include(CrossCompilingExtra)
 
@@ -97,6 +98,7 @@ foreach(_jni_source ${${PROJECT_NAME}_jni_sources})
     "rcljava_common"
     "builtin_interfaces"
     "rcl_interfaces"
+    "rosgraph_msgs"
   )
 
   target_include_directories(${_target_name}
@@ -163,6 +165,7 @@ set(${PROJECT_NAME}_sources
   "src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java"
   "src/main/java/org/ros2/rcljava/time/Clock.java"
   "src/main/java/org/ros2/rcljava/time/ClockType.java"
+  "src/main/java/org/ros2/rcljava/time/TimeSource.java"
   "src/main/java/org/ros2/rcljava/timer/Timer.java"
   "src/main/java/org/ros2/rcljava/timer/WallTimer.java"
   "src/main/java/org/ros2/rcljava/timer/WallTimerImpl.java"
@@ -176,6 +179,7 @@ add_jar("${PROJECT_NAME}_jar"
   ${rcljava_common_JARS}
   ${builtin_interfaces_JARS}
   ${rcl_interfaces_JARS}
+  ${rosgraph_msgs_JARS}
 )
 
 install_jar("${PROJECT_NAME}_jar" "share/${PROJECT_NAME}/java")
@@ -213,6 +217,7 @@ if(BUILD_TESTING)
     DEPENDENCIES
     builtin_interfaces
     rcl_interfaces
+    rosgraph_msgs
     ${_java_type_supports}
     SKIP_INSTALL
   )
@@ -293,6 +298,15 @@ if(BUILD_TESTING)
     list_append_unique(_deps_library_dirs ${_dep_dir})
   endforeach()
 
+  foreach(_dep_lib ${rosgraph_msgs_interfaces_LIBRARIES})
+    get_filename_component(_dep_dir "${_dep_lib}" DIRECTORY)
+    list_append_unique(_deps_library_dirs ${_dep_dir})
+  endforeach()
+  foreach(_dep_lib ${rosgraph_msgs_JNI_LIBRARIES})
+    get_filename_component(_dep_dir "${_dep_lib}" DIRECTORY)
+    list_append_unique(_deps_library_dirs ${_dep_dir})
+  endforeach()
+
   list_append_unique(_deps_library_dirs ${CMAKE_CURRENT_BINARY_DIR})
   list_append_unique(_deps_library_dirs ${CMAKE_CURRENT_BINARY_DIR}/rcljava)
   list_append_unique(_deps_library_dirs ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_java/rcljava/msg/)
@@ -313,6 +327,7 @@ if(BUILD_TESTING)
       "${std_msgs_JARS}"
       "${builtin_interfaces_JARS}"
       "${rcl_interfaces_JARS}"
+      "${rosgraph_msgs_JARS}"
       "${_${PROJECT_NAME}_jar_file}"
       "${_${PROJECT_NAME}_messages_jar_file}"
       APPEND_LIBRARY_DIRS

--- a/rcljava/include/org_ros2_rcljava_time_Clock.h
+++ b/rcljava/include/org_ros2_rcljava_time_Clock.h
@@ -30,6 +30,40 @@ JNICALL Java_org_ros2_rcljava_time_Clock_nativeCreateClockHandle(JNIEnv *, jclas
 
 /*
  * Class:     org_ros2_rcljava_time_Clock
+ * Method:    nativeGetNow
+ * Signature: (J)J
+ */
+JNIEXPORT jlong
+JNICALL Java_org_ros2_rcljava_time_Clock_nativeGetNow(JNIEnv * env, jclass, jlong);
+
+/*
+ * Class:     org_ros2_rcljava_time_Clock
+ * Method:    nativeRosTimeOverrideEnabled
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean
+JNICALL Java_org_ros2_rcljava_time_Clock_nativeRosTimeOverrideEnabled(JNIEnv * env, jclass, jlong);
+
+/*
+ * Class:     org_ros2_rcljava_time_Clock
+ * Method:    nativeSetRosTimeOverrideEnabled
+ * Signature: (JZ)V
+ */
+JNIEXPORT void
+JNICALL Java_org_ros2_rcljava_time_Clock_nativeSetRosTimeOverrideEnabled(
+  JNIEnv * env, jclass, jlong, jboolean);
+
+/*
+ * Class:     org_ros2_rcljava_time_Clock
+ * Method:    nativeSetRosTimeOverride
+ * Signature: (JJ)V
+ */
+JNIEXPORT void
+JNICALL Java_org_ros2_rcljava_time_Clock_nativeSetRosTimeOverride(
+  JNIEnv * env, jclass, jlong, jlong);
+
+/*
+ * Class:     org_ros2_rcljava_time_Clock
  * Method:    nativeDispose
  * Signature: (J)V
  */

--- a/rcljava/package.xml
+++ b/rcljava/package.xml
@@ -17,6 +17,7 @@
   <build_depend>rcl</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>rmw</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <build_depend>rosidl_typesupport_c</build_depend>
   <build_export_depend>builtin_interfaces</build_export_depend>
@@ -31,6 +32,7 @@
   <exec_depend>rcl</exec_depend>
   <exec_depend>rmw_implementation_cmake</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>rosgraph_msgs</exec_depend>
   <exec_depend>rosidl_runtime_c</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
 

--- a/rcljava/package.xml
+++ b/rcljava/package.xml
@@ -23,6 +23,7 @@
   <build_export_depend>builtin_interfaces</build_export_depend>
   <build_export_depend>rcl_interfaces</build_export_depend>
   <build_export_depend>rmw</build_export_depend>
+  <build_export_depend>rosgraph_msgs</build_export_depend>
   <build_export_depend>rosidl_runtime_c</build_export_depend>
   <build_export_depend>rosidl_generator_java</build_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>

--- a/rcljava/src/main/java/org/ros2/rcljava/Time.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Time.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.ros2.rcljava.common.JNIUtils;
 import org.ros2.rcljava.time.ClockType;
 
-public class Time {
+public final class Time {
   private static final Logger logger = LoggerFactory.getLogger(Time.class);
 
   static {

--- a/rcljava/src/main/java/org/ros2/rcljava/Time.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Time.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.ros2.rcljava.common.JNIUtils;
 import org.ros2.rcljava.time.ClockType;
 
-public final class Time {
+public class Time {
   private static final Logger logger = LoggerFactory.getLogger(Time.class);
 
   static {
@@ -35,56 +35,37 @@ public final class Time {
     }
   }
 
-  /**
-   * Private constructor so this cannot be instantiated.
-   */
-  private Time() {}
+  private final ClockType clockType;
 
-  public static builtin_interfaces.msg.Time now() {
-    return Time.now(ClockType.SYSTEM_TIME);
+  private final long nanoseconds;
+
+  public Time() {
+    this(0, 0, ClockType.SYSTEM_TIME);
   }
 
-  public static builtin_interfaces.msg.Time now(ClockType clockType) {
-    long rclTime = 0;
+  public Time(final long nanos, final ClockType ct) {
+    this(0, nanos, ct);
+  }
 
-    switch (clockType) {
-      case ROS_TIME:
-        throw new UnsupportedOperationException("ROS Time is currently not implemented");
-      case SYSTEM_TIME:
-        rclTime = rclSystemTimeNow();
-        break;
-      case STEADY_TIME:
-        rclTime = rclSteadyTimeNow();
-        break;
+  public Time(final builtin_interfaces.msg.Time time_msg, final ClockType ct) {
+    this(time_msg.getSec(), time_msg.getNanosec(), ct);
+  }
+
+  public Time(final long secs, final long nanos, final ClockType ct) {
+    if (secs < 0 || nanos < 0) {
+      // TODO(clalancette): Make this a custom exception
+      throw new IllegalArgumentException("seconds and nanoseconds must not be negative");
     }
-
-    builtin_interfaces.msg.Time msgTime = new builtin_interfaces.msg.Time();
-    msgTime.setSec((int) TimeUnit.SECONDS.convert(rclTime, TimeUnit.NANOSECONDS));
-    msgTime.setNanosec((int) rclTime % (1000 * 1000 * 1000));
-    return msgTime;
+    this.clockType = ct;
+    this.nanoseconds = TimeUnit.SECONDS.toNanos(secs) + nanos;
   }
 
-  public static long toNanoseconds(builtin_interfaces.msg.Time msgTime) {
-    return TimeUnit.NANOSECONDS.convert(msgTime.getSec(), TimeUnit.SECONDS)
-        + (msgTime.getNanosec() & 0x00000000ffffffffL);
+
+  public long nanoseconds() {
+    return nanoseconds;
   }
 
-  public static long difference(
-      builtin_interfaces.msg.Time msgTime1, builtin_interfaces.msg.Time msgTime2) {
-    long difference =
-        (Time.toNanoseconds(msgTime1) - Time.toNanoseconds(msgTime2)) & 0x00000000ffffffffL;
-    return difference;
+  public ClockType clockType() {
+    return clockType;
   }
-
-  private static long rclSystemTimeNow() {
-    return nativeRCLSystemTimeNow(); // new RuntimeException("Could not get current time");
-  }
-
-  private static long rclSteadyTimeNow() {
-    return nativeRCLSteadyTimeNow(); // new RuntimeException("Could not get current time");
-  }
-
-  private static native long nativeRCLSystemTimeNow();
-
-  private static native long nativeRCLSteadyTimeNow();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -42,6 +42,7 @@ import org.ros2.rcljava.subscription.Subscription;
 import org.ros2.rcljava.subscription.SubscriptionImpl;
 import org.ros2.rcljava.time.Clock;
 import org.ros2.rcljava.time.ClockType;
+import org.ros2.rcljava.time.TimeSource;
 import org.ros2.rcljava.timer.Timer;
 import org.ros2.rcljava.timer.WallTimer;
 import org.ros2.rcljava.timer.WallTimerImpl;
@@ -96,6 +97,8 @@ public class NodeImpl implements Node {
    */
   private Clock clock;
 
+  private TimeSource timeSource;
+
   /**
    * All the @{link Subscription}s that have been created through this instance.
    */
@@ -141,7 +144,6 @@ public class NodeImpl implements Node {
    *     be zero.
    */
   public NodeImpl(final long handle, final Context context, final boolean allowUndeclaredParameters) {
-    this.clock = new Clock(ClockType.SYSTEM_TIME);
     this.handle = handle;
     this.context = context;
     this.publishers = new LinkedBlockingQueue<Publisher>();
@@ -154,6 +156,9 @@ public class NodeImpl implements Node {
     this.allowUndeclaredParameters = allowUndeclaredParameters;
     this.parameterCallbacksMutex = new Object();
     this.parameterCallbacks = new ArrayList<ParameterCallback>();
+    this.clock = new Clock(ClockType.ROS_TIME);
+    this.timeSource = new TimeSource(this);
+    this.timeSource.attachClock(this.clock);
   }
 
   /**

--- a/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
@@ -25,18 +25,23 @@ import org.ros2.rcljava.time.Clock;
 import org.ros2.rcljava.time.ClockType;
 import org.ros2.rcljava.Time;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.List;
 
 import java.util.concurrent.LinkedBlockingQueue;
 
-public class TimeSource {
+public final class TimeSource {
   private Node node;
   private boolean rosTimeIsActive;
   private final Collection<Clock> associatedClocks;
   private Subscription<rosgraph_msgs.msg.Clock> clockSub;
   private Time lastTimeSet;
   private ParameterCallback simTimeCB;
+
+  private static final Logger logger = LoggerFactory.getLogger(TimeSource.class);
 
   public TimeSource() {
     this(null);
@@ -108,8 +113,9 @@ public class TimeSource {
     if (useSimTimeType != ParameterType.PARAMETER_NOT_SET) {
       if (useSimTimeType == ParameterType.PARAMETER_BOOL) {
         this.rosTimeIsActive = useSimTime.asBool();
+      } else {
+        logger.warn("The 'use_sim_time' parameter must be a boolean");
       }
-      // TODO(clalancette): what to do if it is the wrong type?
     }
 
     class SimTimeCB implements ParameterCallback {

--- a/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
@@ -25,13 +25,15 @@ import org.ros2.rcljava.time.Clock;
 import org.ros2.rcljava.time.ClockType;
 import org.ros2.rcljava.Time;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class TimeSource {
   private Node node;
   private boolean rosTimeIsActive;
-  private ArrayList<Clock> associatedClocks;
+  private final Collection<Clock> associatedClocks;
   private Subscription<rosgraph_msgs.msg.Clock> clockSub;
   private Time lastTimeSet;
   private ParameterCallback simTimeCB;
@@ -42,7 +44,7 @@ public class TimeSource {
 
   public TimeSource(Node node) {
     this.rosTimeIsActive = false;
-    this.associatedClocks = new ArrayList<Clock>();
+    this.associatedClocks = new LinkedBlockingQueue<Clock>();
     this.clockSub = null;
     this.lastTimeSet = new Time(0, 0, ClockType.ROS_TIME);
     if (node != null) {
@@ -157,5 +159,9 @@ public class TimeSource {
     clock.setRosTimeOverride(this.lastTimeSet);
     clock.setRosTimeIsActive(this.rosTimeIsActive);
     this.associatedClocks.add(clock);
+  }
+
+  public void detachClock(Clock clock) {
+    this.associatedClocks.remove(clock);
   }
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
@@ -1,0 +1,161 @@
+/* Copyright 2020 Open Source Robotics Foundation, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava.time;
+
+import org.ros2.rcljava.consumers.Consumer;
+import org.ros2.rcljava.node.Node;
+import org.ros2.rcljava.parameters.ParameterCallback;
+import org.ros2.rcljava.parameters.ParameterType;
+import org.ros2.rcljava.parameters.ParameterVariant;
+import org.ros2.rcljava.subscription.Subscription;
+import org.ros2.rcljava.time.Clock;
+import org.ros2.rcljava.time.ClockType;
+import org.ros2.rcljava.Time;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TimeSource {
+  private Node node;
+  private boolean rosTimeIsActive;
+  private ArrayList<Clock> associatedClocks;
+  private Subscription<rosgraph_msgs.msg.Clock> clockSub;
+  private Time lastTimeSet;
+  private ParameterCallback simTimeCB;
+
+  public TimeSource() {
+    this(null);
+  }
+
+  public TimeSource(Node node) {
+    this.rosTimeIsActive = false;
+    this.associatedClocks = new ArrayList<Clock>();
+    this.clockSub = null;
+    this.lastTimeSet = new Time(0, 0, ClockType.ROS_TIME);
+    if (node != null) {
+      this.attachNode(node);
+    }
+  }
+
+  public boolean getRosTimeIsActive() {
+    return this.rosTimeIsActive;
+  }
+
+  class SubscriptionCallback implements Consumer<rosgraph_msgs.msg.Clock> {
+    private TimeSource timeSource;
+
+    SubscriptionCallback(TimeSource ts) {
+      this.timeSource = ts;
+    }
+
+    public void accept(final rosgraph_msgs.msg.Clock msg) {
+      Time timeFromMsg = new Time(msg.getClock(), ClockType.ROS_TIME);
+      this.timeSource.lastTimeSet = timeFromMsg;
+      for (Clock clock : this.timeSource.associatedClocks) {
+        clock.setRosTimeOverride(timeFromMsg);
+      }
+    }
+  }
+
+  public void setRosTimeIsActive(boolean enabled) {
+    if (this.rosTimeIsActive == enabled) {
+      return;
+    }
+    this.rosTimeIsActive = enabled;
+    for (Clock clock : this.associatedClocks) {
+      clock.setRosTimeIsActive(enabled);
+    }
+    if (enabled) {
+      if (this.node != null) {
+        this.clockSub = node.<rosgraph_msgs.msg.Clock>createSubscription(rosgraph_msgs.msg.Clock.class, "/clock", new SubscriptionCallback(this));
+      }
+    } else {
+      if (this.node != null && this.clockSub != null) {
+        this.node.removeSubscription(this.clockSub);
+        this.clockSub = null;
+      }
+    }
+  }
+
+  public void attachNode(Node node) {
+    if (this.node != null) {
+      detachNode();
+    }
+
+    this.node = node;
+
+    if (!this.node.hasParameter("use_sim_time")) {
+      this.node.declareParameter(new ParameterVariant("use_sim_time", false));
+    }
+
+    ParameterVariant useSimTime = this.node.getParameter("use_sim_time");
+    ParameterType useSimTimeType = useSimTime.getType();
+    if (useSimTimeType != ParameterType.PARAMETER_NOT_SET) {
+      if (useSimTimeType == ParameterType.PARAMETER_BOOL) {
+        this.rosTimeIsActive = useSimTime.asBool();
+      }
+      // TODO(clalancette): what to do if it is the wrong type?
+    }
+
+    class SimTimeCB implements ParameterCallback {
+      private TimeSource timeSource;
+
+      public SimTimeCB(TimeSource ts) {
+        this.timeSource = ts;
+      }
+
+      public rcl_interfaces.msg.SetParametersResult callback(List<ParameterVariant> parameters) {
+        rcl_interfaces.msg.SetParametersResult result = new rcl_interfaces.msg.SetParametersResult();
+        result.setSuccessful(true);
+        for (ParameterVariant param : parameters) {
+          if (param.getName() == "use_sim_time") {
+            if (param.getType() == ParameterType.PARAMETER_BOOL) {
+              this.timeSource.rosTimeIsActive = param.asBool();
+            } else {
+              result.setSuccessful(false);
+              result.setReason("'use_sim_time' parameter must be a boolean");
+              break;
+            }
+          }
+        }
+        return result;
+      }
+    }
+
+    this.simTimeCB = new SimTimeCB(this);
+
+    this.node.addOnSetParametersCallback(this.simTimeCB);
+  }
+
+  public void detachNode() {
+    if (this.node == null) {
+      return;
+    }
+    this.setRosTimeIsActive(false);
+    this.node.removeOnSetParametersCallback(this.simTimeCB);
+    this.node = null;
+  }
+
+  public void attachClock(Clock clock) {
+    if (clock.getClockType() != ClockType.ROS_TIME) {
+      // TODO(clalancette): Make this a custom exception
+      throw new IllegalArgumentException("Cannot attach a clock that is not ROS_TIME to a timesource");
+    }
+    clock.setRosTimeOverride(this.lastTimeSet);
+    clock.setRosTimeIsActive(this.rosTimeIsActive);
+    this.associatedClocks.add(clock);
+  }
+}

--- a/rcljava/src/test/java/org/ros2/rcljava/TimeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/TimeTest.java
@@ -16,9 +16,6 @@
 package org.ros2.rcljava;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.concurrent.TimeUnit;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -33,50 +30,34 @@ public class TimeTest {
     org.apache.log4j.BasicConfigurator.configure();
   }
 
-  // @Test
-  public final void testSystemTime() {
-    builtin_interfaces.msg.Time now = Time.now(ClockType.SYSTEM_TIME);
-    long javaNowMillis = System.currentTimeMillis();
-
-    long nowNanos = Time.toNanoseconds(now);
-    long javaNowNanos = TimeUnit.NANOSECONDS.convert(javaNowMillis, TimeUnit.MILLISECONDS);
-
-    long tolerance = TimeUnit.NANOSECONDS.convert(1000, TimeUnit.MILLISECONDS);
-    assertEquals(javaNowNanos, nowNanos, tolerance);
-  }
-
-  // @Test
-  public final void testSteadyTime() {
-    int millisecondsToSleep = 100;
-    builtin_interfaces.msg.Time now = Time.now(ClockType.STEADY_TIME);
-    long javaNowNanos = System.nanoTime();
-
-    try {
-      Thread.sleep(millisecondsToSleep);
-    } catch (InterruptedException iex) {
-      fail("Failed to sleep for " + millisecondsToSleep + " milliseconds");
-    }
-
-    builtin_interfaces.msg.Time later = Time.now(ClockType.STEADY_TIME);
-
-    long javaLaterNanos = System.nanoTime();
-
-    long tolerance = TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS);
-
-    long javaDifference = javaLaterNanos - javaNowNanos;
-    long difference = Time.difference(later, now);
-    assertEquals(javaDifference, difference, tolerance);
+  @Test
+  public final void testTimeNoArgConstructor() {
+    Time time = new Time();
+    assertEquals(0, time.nanoseconds());
+    assertEquals(ClockType.SYSTEM_TIME, time.clockType());
   }
 
   @Test
-  public final void testROSTime() {
-    builtin_interfaces.msg.Time startTime;
-    try {
-      startTime = Time.now(ClockType.ROS_TIME);
-    } catch (UnsupportedOperationException uoe) {
-      return;
-    }
+  public final void testTimeNanos() {
+    Time time = new Time(45, ClockType.SYSTEM_TIME);
+    assertEquals(45, time.nanoseconds());
+    assertEquals(ClockType.SYSTEM_TIME, time.clockType());
+  }
 
-    fail("ROS time is not supported yet");
+  @Test
+  public final void testTimeAllArgs() {
+    Time time = new Time(0, 45, ClockType.SYSTEM_TIME);
+    assertEquals(45, time.nanoseconds());
+    assertEquals(ClockType.SYSTEM_TIME, time.clockType());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public final void testTimeBadSecs() {
+    Time time = new Time(-1, 0, ClockType.SYSTEM_TIME);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public final void testTimeBadNanos() {
+    Time time = new Time(0, -45, ClockType.SYSTEM_TIME);
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeParametersTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeParametersTest.java
@@ -337,7 +337,8 @@ public class NodeParametersTest {
     node.declareParameter(new ParameterVariant("thing.do", true));
 
     rcl_interfaces.msg.ListParametersResult result = node.listParameters(new ArrayList<String>(), rcl_interfaces.srv.ListParameters_Request.DEPTH_RECURSIVE);
-    assertEquals(2, result.getNames().size());
+    // 2 we added above plus the implicit "use_sim_time"
+    assertEquals(3, result.getNames().size());
   }
 
   @Test


### PR DESCRIPTION
This PR does the bare minimum to implement 'use_sim_time' in rcljava.  By 'bare minimum', I mean:

1.  It revamps the `Time` class to be more like the rclcpp/rclpy equivalents.
1.  It revamps the `Clock` class to be more like the rclcpp/rclpy equivalents.
1.  It implements the `TimeSource` class, which is responsible for setting up the 'use_sim_time' parameter and subscribing to the '/clock' topic.
1.  The current tests pass.
1.  New tests for the revamped `Time` class were added.
1.  No new tests for `Clock` or `TimeSource` were added.
1.  There are still a few (relatively minor) TODO comments in the code.
1.  I didn't test that this actually, you know, works.

Nevertheless, I think this is a good starting point to finish implementing 'use_sim_time'.  The next steps here are to write tests, fix the TODOs, and then test that 'use_sim_time' actually works.

FYI, this builds on top of #3 , so some of those commits are in here as well.  Once #3 is reviewed/merged, this one should be rebased.

@jacobperron @ivanpauno FYI.