### PR TITLE
Add support for event handlers in Executor

### DIFF
--- a/rcljava/include/org_ros2_rcljava_executors_BaseExecutor.h
+++ b/rcljava/include/org_ros2_rcljava_executors_BaseExecutor.h
@@ -136,6 +136,15 @@ JNICALL Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetAddTimer(
 
 /*
  * Class:     org_ros2_rcljava_executors_BaseExecutor
+ * Method:    nativeWaitSetAddEvent
+ * Signature: (JJ)V
+ */
+JNIEXPORT void
+JNICALL Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetAddEvent(
+  JNIEnv *, jclass, jlong, jlong);
+
+/*
+ * Class:     org_ros2_rcljava_executors_BaseExecutor
  * Method:    nativeWaitSetSubscriptionIsReady
  * Signature: (JJ)Z
  */
@@ -150,6 +159,15 @@ JNICALL Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetSubscriptionIs
  */
 JNIEXPORT jboolean
 JNICALL Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetTimerIsReady(
+  JNIEnv *, jclass, jlong, jlong);
+
+/*
+ * Class:     org_ros2_rcljava_executors_BaseExecutor
+ * Method:    nativeWaitSetEventIsReady
+ * Signature: (JJ)Z
+ */
+JNIEXPORT jboolean
+JNICALL Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetEventIsReady(
   JNIEnv *, jclass, jlong, jlong);
 
 /*

--- a/rcljava/src/main/cpp/org_ros2_rcljava_executors_BaseExecutor.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_executors_BaseExecutor.cpp
@@ -276,6 +276,21 @@ Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetAddTimer(
   }
 }
 
+JNIEXPORT void JNICALL
+Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetAddEvent(
+  JNIEnv * env, jclass, jlong wait_set_handle, jlong event_handle)
+{
+  auto * wait_set = reinterpret_cast<rcl_wait_set_t *>(wait_set_handle);
+  auto * event = reinterpret_cast<rcl_event_t *>(event_handle);
+  rcl_ret_t ret = rcl_wait_set_add_event(wait_set, event, nullptr);
+  if (ret != RCL_RET_OK) {
+    std::string msg =
+      "Failed to add event to wait set: " + std::string(rcl_get_error_string().str);
+    rcl_reset_error();
+    rcljava_throw_rclexception(env, ret, msg);
+  }
+}
+
 JNIEXPORT jobject JNICALL
 Java_org_ros2_rcljava_executors_BaseExecutor_nativeTakeRequest(
   JNIEnv * env, jclass, jlong service_handle, jlong jrequest_from_java_converter_handle,
@@ -433,6 +448,14 @@ Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetTimerIsReady(
 {
   rcl_wait_set_t * wait_set = reinterpret_cast<rcl_wait_set_t *>(wait_set_handle);
   return wait_set->timers[index] != nullptr;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_ros2_rcljava_executors_BaseExecutor_nativeWaitSetEventIsReady(
+  JNIEnv *, jclass, jlong wait_set_handle, jlong index)
+{
+  rcl_wait_set_t * wait_set = reinterpret_cast<rcl_wait_set_t *>(wait_set_handle);
+  return wait_set->events[index] != nullptr;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/AnyExecutable.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/AnyExecutable.java
@@ -16,6 +16,7 @@
 package org.ros2.rcljava.executors;
 
 import org.ros2.rcljava.client.Client;
+import org.ros2.rcljava.events.EventHandler;
 import org.ros2.rcljava.subscription.Subscription;
 import org.ros2.rcljava.service.Service;
 import org.ros2.rcljava.timer.Timer;
@@ -25,4 +26,5 @@ public class AnyExecutable {
   public Subscription subscription;
   public Service service;
   public Client client;
+  public EventHandler eventHandler;
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/publisher/Publisher.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/publisher/Publisher.java
@@ -16,6 +16,7 @@
 package org.ros2.rcljava.publisher;
 
 import java.lang.ref.WeakReference;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.ros2.rcljava.consumers.Consumer;
@@ -64,4 +65,11 @@ public interface Publisher<T extends MessageDefinition> extends Disposable {
    */
   <T extends PublisherEventStatus> void removeEventHandler(
     EventHandler<T, Publisher> eventHandler);
+
+  /**
+   * Get the event handlers that were registered in this Publisher.
+   *
+   * @return The registered event handlers.
+   */
+  Collection<EventHandler> getEventHandlers();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
@@ -139,7 +139,15 @@ public class PublisherImpl<T extends MessageDefinition> implements Publisher<T> 
   }
 
   /**
-   * Create a publisher event (rcl_event_t).
+   * {@inheritDoc}
+   */
+  public final
+  Collection<EventHandler> getEventHandlers() {
+    return this.eventHandlers;
+  }
+
+  /**
+   * Create a publisher event (rcl_event_t)
    *
    * The ownership of the created event handle will immediately be transferred to an
    * @{link EventHandlerImpl}, that will be responsible of disposing it.


### PR DESCRIPTION
What the title says :point_up: .

I haven't added a test for this yet.
I need first to have an event that I can trigger reliably, and I cannot do that with liveliness lost because a lot of API is missing for that (manually assert liveliness API, liveliness policy in QoSProfile, ...).

I think that I will add support to a different event type that can be triggered more easily (maybe I can still get a liveliness lost event with automatic liveliness, I have to double check).

We also should double check what subset of the events machinery we actually need.

---

On a different note, the current executor code is a bit complex and a lots of things could be simplified (there's a lot of unnecessary iterations that could be merged). I didn't aim to fix that here.

There's also an ownership problem: if you dispose a `Subscription` and that `Subscription` is being used in another thread by an Executor, a segfault is likely to happen.

Last but not least: the multithreaded executor [creates a bunch of threads that are mutually exclusive](https://github.com/osrf/ros2_java/blob/62918477f4fb8810d4df0ac9c9e67b885b635d01/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java#L62-L81), so only one thread can do something at a time.
If wait/execute aren't decoupled the multithreaded executor isn't really useful :joy: .