### PR TITLE
Add support for events in subscriptions

### DIFF
--- a/rcljava/include/org_ros2_rcljava_subscription_SubscriptionImpl.h
+++ b/rcljava/include/org_ros2_rcljava_subscription_SubscriptionImpl.h
@@ -29,6 +29,15 @@ JNIEXPORT void
 JNICALL Java_org_ros2_rcljava_subscription_SubscriptionImpl_nativeDispose(
   JNIEnv *, jclass, jlong, jlong);
 
+/*
+ * Class:     org_ros2_rcljava_subscription_SubscriptionImpl
+ * Method:    nativeCreateEvent
+ * Signature: (JJ)J
+ */
+JNIEXPORT jlong
+JNICALL Java_org_ros2_rcljava_subscription_SubscriptionImpl_nativeCreateEvent(
+  JNIEnv *, jclass, jlong, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
@@ -181,6 +181,11 @@ public class BaseExecutor {
       for (Subscription<MessageDefinition> subscription : node.getNode().getSubscriptions()) {
         this.subscriptionHandles.add(new AbstractMap.SimpleEntry<Long, Subscription>(
             subscription.getHandle(), subscription));
+        Collection<EventHandler> eventHandlers = subscription.getEventHandlers();
+        for (EventHandler eventHandler : eventHandlers) {
+          this.eventHandles.add(new AbstractMap.SimpleEntry<Long, EventHandler>(
+            eventHandler.getHandle(), eventHandler));
+        }
       }
 
       for (Publisher publisher : node.getNode().getPublishers()) {

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/Subscription.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/Subscription.java
@@ -16,8 +16,12 @@
 package org.ros2.rcljava.subscription;
 
 import java.lang.ref.WeakReference;
+import java.util.Collection;
+import java.util.function.Supplier;
 
 import org.ros2.rcljava.consumers.Consumer;
+import org.ros2.rcljava.events.EventHandler;
+import org.ros2.rcljava.events.SubscriptionEventStatus;
 import org.ros2.rcljava.interfaces.Disposable;
 import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.node.Node;
@@ -42,4 +46,30 @@ public interface Subscription<T extends MessageDefinition> extends Disposable {
   WeakReference<Node> getNodeReference();
 
   void executeCallback(T message);
+
+  /**
+   * Create an event handler.
+   *
+   * @param <T> A subscription event status type.
+   * @param factory A factory that can instantiate an event status of type T.
+   * @param callback Callback that will be called when the event is triggered.
+   */
+  <T extends SubscriptionEventStatus> EventHandler<T, Subscription> createEventHandler(
+    Supplier<T> factory, Consumer<T> callback);
+
+  /**
+   * Remove a previously registered event handler.
+   *
+   * @param <T> A subscription event status type.
+   * @param eventHandler An event handler that was registered previously in this object.
+   */
+  <T extends SubscriptionEventStatus> void removeEventHandler(
+    EventHandler<T, Subscription> eventHandler);
+
+  /**
+   * Get the event handlers that were registered in this Publisher.
+   *
+   * @return The registered event handlers.
+   */
+  Collection<EventHandler> getEventHandlers();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/Subscription.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/Subscription.java
@@ -67,7 +67,7 @@ public interface Subscription<T extends MessageDefinition> extends Disposable {
     EventHandler<T, Subscription> eventHandler);
 
   /**
-   * Get the event handlers that were registered in this Publisher.
+   * Get the event handlers that were registered in this Subscription.
    *
    * @return The registered event handlers.
    */

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
@@ -164,7 +164,7 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
    * The ownership of the created event handle will immediately be transferred to an
    * @{link EventHandlerImpl}, that will be responsible of disposing it.
    *
-   * @param handle A pointer to the underlying ROS2 subscription structure.
+   * @param handle A pointer to the underlying ROS 2 subscription structure.
    *     Must not be zero.
    * @param eventType The rcl event type.
    */

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
@@ -16,10 +16,16 @@
 package org.ros2.rcljava.subscription;
 
 import java.lang.ref.WeakReference;
+import java.util.Collection;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
 
 import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.common.JNIUtils;
 import org.ros2.rcljava.consumers.Consumer;
+import org.ros2.rcljava.events.EventHandler;
+import org.ros2.rcljava.events.EventHandlerImpl;
+import org.ros2.rcljava.events.SubscriptionEventStatus;
 import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.node.Node;
 
@@ -68,6 +74,8 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
    */
   private final Consumer<T> callback;
 
+  private final Collection<EventHandler> eventHandlers;
+
   /**
    * Constructor.
    *
@@ -90,6 +98,7 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
     this.messageType = messageType;
     this.topic = topic;
     this.callback = callback;
+    this.eventHandlers = new LinkedBlockingQueue<EventHandler>();
   }
 
   /**
@@ -114,6 +123,54 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public final
+  <T extends SubscriptionEventStatus> EventHandler<T, Subscription>
+  createEventHandler(Supplier<T> factory, Consumer<T> callback) {
+    T status = factory.get();
+    long eventHandle = nativeCreateEvent(this.handle, status.getSubscriptionEventType());
+    EventHandler<T, Subscription> eventHandler = new EventHandlerImpl(
+      new WeakReference<Subscription>(this), eventHandle, factory, callback);
+    this.eventHandlers.add(eventHandler);
+    return eventHandler;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final
+  <T extends SubscriptionEventStatus> void removeEventHandler(
+    EventHandler<T, Subscription> eventHandler)
+  {
+    if (!this.eventHandlers.remove(eventHandler)) {
+      throw new IllegalArgumentException(
+        "The passed eventHandler wasn't created by this subscription");
+    }
+    eventHandler.dispose();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public final
+  Collection<EventHandler> getEventHandlers() {
+    return this.eventHandlers;
+  }
+
+  /**
+   * Create a subscription event (rcl_event_t)
+   *
+   * The ownership of the created event handle will immediately be transferred to an
+   * @{link EventHandlerImpl}, that will be responsible of disposing it.
+   *
+   * @param handle A pointer to the underlying ROS2 subscription structure.
+   *     Must not be zero.
+   * @param eventType The rcl event type.
+   */
+  private static native long nativeCreateEvent(long handle, int eventType);
+
+  /**
    * Destroy a ROS2 subscription (rcl_subscription_t).
    *
    * @param nodeHandle A pointer to the underlying ROS2 node structure that
@@ -127,6 +184,10 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
    * {@inheritDoc}
    */
   public final void dispose() {
+    for (EventHandler eventHandler : this.eventHandlers) {
+      eventHandler.dispose();
+    }
+    this.eventHandlers.clear();
     Node node = this.nodeReference.get();
     if (node != null) {
       node.removeSubscription(this);


### PR DESCRIPTION
This PR implements event handlers for subscriptions.

I haven't added bindings for a subscription status yet, so I have not written tests.
Next PR is going to be that. After that, we can merge `feature/events` branch into `foxy-devel`.