### PR TITLE
Autoremove EventHandler from parent entity

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/events/EventHandlerImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/events/EventHandlerImpl.java
@@ -64,19 +64,19 @@ implements EventHandler<T, ParentT> {
    * @param eventStatusFactory Factory of an event status.
    * @param callback The callback function that will be called when the event
    *     is triggered.
-   * @param removeCallback Callback that will be called when this object is being disposed.
+   * @param disposeCallback Callback that will be called when this object is disposed.
    */
   public EventHandlerImpl(
       final WeakReference<ParentT> parentReference,
       final long handle,
       final Supplier<T> eventStatusFactory,
       final Consumer<T> callback,
-      final Consumer<EventHandler> removeCallback) {
+      final Consumer<EventHandler> disposeCallback) {
     this.parentReference = parentReference;
     this.handle = handle;
     this.eventStatusFactory = eventStatusFactory;
     this.callback = callback;
-    this.removeCallback = removeCallback;
+    this.disposeCallback = disposeCallback;
   }
 
   /**
@@ -108,7 +108,7 @@ implements EventHandler<T, ParentT> {
     if (this.handle == 0) {
       return;
     }
-    this.removeCallback.accept(this);
+    this.disposeCallback.accept(this);
     nativeDispose(this.handle);
     this.handle = 0;
   }
@@ -138,5 +138,5 @@ implements EventHandler<T, ParentT> {
   private final WeakReference<ParentT> parentReference;
   private long handle;
   private final Consumer<T> callback;
-  private final Consumer<EventHandler> removeCallback;
+  private final Consumer<EventHandler> disposeCallback;
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/events/EventHandlerImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/events/EventHandlerImpl.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 
 import org.ros2.rcljava.common.JNIUtils;
 import org.ros2.rcljava.consumers.Consumer;
-import org.ros2.rcljava.consumers.Consumer;
 import org.ros2.rcljava.events.EventHandler;
 import org.ros2.rcljava.events.EventStatus;
 import org.ros2.rcljava.interfaces.Disposable;

--- a/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
@@ -119,7 +119,7 @@ public class PublisherImpl<T extends MessageDefinition> implements Publisher<T> 
   createEventHandler(Supplier<T> factory, Consumer<T> callback) {
     final WeakReference<Collection<EventHandler>> weakEventHandlers = new WeakReference(
       this.eventHandlers);
-    Consumer<EventHandler> removeCallback = new Consumer<EventHandler>() {
+    Consumer<EventHandler> disposeCallback = new Consumer<EventHandler>() {
       public void accept(EventHandler eventHandler) {
         Collection<EventHandler> eventHandlers = weakEventHandlers.get();
         if (eventHandlers != null) {
@@ -130,7 +130,7 @@ public class PublisherImpl<T extends MessageDefinition> implements Publisher<T> 
     T status = factory.get();
     long eventHandle = nativeCreateEvent(this.handle, status.getPublisherEventType());
     EventHandler<T, Publisher> eventHandler = new EventHandlerImpl(
-      new WeakReference<Publisher>(this), eventHandle, factory, callback, removeCallback);
+      new WeakReference<Publisher>(this), eventHandle, factory, callback, disposeCallback);
     this.eventHandlers.add(eventHandler);
     return eventHandler;
   }

--- a/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
@@ -117,10 +117,20 @@ public class PublisherImpl<T extends MessageDefinition> implements Publisher<T> 
   public final
   <T extends PublisherEventStatus> EventHandler<T, Publisher>
   createEventHandler(Supplier<T> factory, Consumer<T> callback) {
+    final WeakReference<Collection<EventHandler>> weakEventHandlers = new WeakReference(
+      this.eventHandlers);
+    Consumer<EventHandler> removeCallback = new Consumer<EventHandler>() {
+      public void accept(EventHandler eventHandler) {
+        Collection<EventHandler> eventHandlers = weakEventHandlers.get();
+        if (eventHandlers != null) {
+          eventHandlers.remove(eventHandler);
+        }
+      }
+    };
     T status = factory.get();
     long eventHandle = nativeCreateEvent(this.handle, status.getPublisherEventType());
     EventHandler<T, Publisher> eventHandler = new EventHandlerImpl(
-      new WeakReference<Publisher>(this), eventHandle, factory, callback);
+      new WeakReference<Publisher>(this), eventHandle, factory, callback, removeCallback);
     this.eventHandlers.add(eventHandler);
     return eventHandler;
   }

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.common.JNIUtils;
+import org.ros2.rcljava.consumers.BiConsumer;
 import org.ros2.rcljava.consumers.Consumer;
 import org.ros2.rcljava.events.EventHandler;
 import org.ros2.rcljava.events.EventHandlerImpl;
@@ -128,10 +129,20 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
   public final
   <T extends SubscriptionEventStatus> EventHandler<T, Subscription>
   createEventHandler(Supplier<T> factory, Consumer<T> callback) {
+    final WeakReference<Collection<EventHandler>> weakEventHandlers = new WeakReference(
+      this.eventHandlers);
+    Consumer<EventHandler> removeCallback = new Consumer<EventHandler>() {
+      public void accept(EventHandler eventHandler) {
+        Collection<EventHandler> eventHandlers = weakEventHandlers.get();
+        if (eventHandlers != null) {
+          eventHandlers.remove(eventHandler);
+        }
+      }
+    };
     T status = factory.get();
     long eventHandle = nativeCreateEvent(this.handle, status.getSubscriptionEventType());
     EventHandler<T, Subscription> eventHandler = new EventHandlerImpl(
-      new WeakReference<Subscription>(this), eventHandle, factory, callback);
+      new WeakReference<Subscription>(this), eventHandle, factory, callback, removeCallback);
     this.eventHandlers.add(eventHandler);
     return eventHandler;
   }

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
@@ -131,7 +131,7 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
   createEventHandler(Supplier<T> factory, Consumer<T> callback) {
     final WeakReference<Collection<EventHandler>> weakEventHandlers = new WeakReference(
       this.eventHandlers);
-    Consumer<EventHandler> removeCallback = new Consumer<EventHandler>() {
+    Consumer<EventHandler> disposeCallback = new Consumer<EventHandler>() {
       public void accept(EventHandler eventHandler) {
         Collection<EventHandler> eventHandlers = weakEventHandlers.get();
         if (eventHandlers != null) {
@@ -142,7 +142,7 @@ public class SubscriptionImpl<T extends MessageDefinition> implements Subscripti
     T status = factory.get();
     long eventHandle = nativeCreateEvent(this.handle, status.getSubscriptionEventType());
     EventHandler<T, Subscription> eventHandler = new EventHandlerImpl(
-      new WeakReference<Subscription>(this), eventHandle, factory, callback, removeCallback);
+      new WeakReference<Subscription>(this), eventHandle, factory, callback, disposeCallback);
     this.eventHandlers.add(eventHandler);
     return eventHandler;
   }

--- a/rcljava/src/test/java/org/ros2/rcljava/publisher/PublisherTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/publisher/PublisherTest.java
@@ -90,9 +90,12 @@ public class PublisherTest {
       }
     );
     assertNotEquals(0, eventHandler.getHandle());
+    assertEquals(1, publisher.getEventHandlers().size());
     // force executing the callback, so we check that taking an event works
     eventHandler.executeCallback();
-    RCLJava.shutdown();
+    eventHandler.dispose();
     assertEquals(0, eventHandler.getHandle());
+    assertEquals(0, publisher.getEventHandlers().size());
+    RCLJava.shutdown();
   }
 }


### PR DESCRIPTION
Depends on #13.

I can add an equivalent test for subscription events after https://github.com/osrf/ros2_java/pull/14 gets in.