### PR TITLE
Add tests for TimeSource

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.25
       with:
         required-ros-distributions: foxy
-    - uses: jacobperron/action-ros-ci@remove_vcs_dir
+    - uses: ros-tooling/action-ros-ci@master
       with:
         package-name: rosidl_generator_java rcljava_common rcljava
         target-ros2-distro: foxy

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.25
       with:
         required-ros-distributions: foxy
-    - uses: ros-tooling/action-ros-ci@0.0.19
+    - uses: jacobperron/action-ros-ci@remove_vcs_dir
       with:
         package-name: rosidl_generator_java rcljava_common rcljava
         target-ros2-distro: foxy

--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -188,37 +188,8 @@ ament_export_jars("share/${PROJECT_NAME}/java/${PROJECT_NAME}.jar")
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(std_msgs REQUIRED)
+  find_package(mockito_vendor REQUIRED)
   ament_lint_auto_find_test_dependencies()
-
-  # Find mockito and it's dependencies
-  # TODO(jacobperron): Wrap this into cmake helper
-  find_jar(MOCKITO_JAR NAME mockito-core)
-  find_jar(BYTE_BUDDY_JAR NAME byte-buddy)
-  find_jar(BYTE_BUDDY_AGENT_JAR NAME byte-buddy-agent)
-  find_jar(OBJENESIS_JAR NAME objenesis)
-
-  if(NOT MOCKITO_JAR)
-    message(FATAL_ERROR "mockito installation not found")
-  endif()
-
-  if(NOT BYTE_BUDDY_JAR)
-    message(FATAL_ERROR "byte-buddy installation not found (mockito dependency)")
-  endif()
-
-  if(NOT BYTE_BUDDY_AGENT_JAR)
-    message(FATAL_ERROR "byte-buddy-agent installation not found (mockito dependency)")
-  endif()
-
-  if(NOT OBJENESIS_JAR)
-    message(FATAL_ERROR "objenesis installation not found (mockito dependency)")
-  endif()
-
-  set(MOCKITO_JARS
-    "${MOCKITO_JAR}"
-    "${BYTE_BUDDY_JAR}"
-    "${BYTE_BUDDY_AGENT_JAR}"
-    "${OBJENESIS_JAR}"
-  )
 
   set(${PROJECT_NAME}_message_files
     "msg/BoundedArrayNested.msg"
@@ -360,9 +331,9 @@ if(BUILD_TESTING)
       "${builtin_interfaces_JARS}"
       "${rcl_interfaces_JARS}"
       "${rosgraph_msgs_JARS}"
+      "${mockito_vendor_JARS}"
       "${_${PROJECT_NAME}_jar_file}"
       "${_${PROJECT_NAME}_messages_jar_file}"
-      "${MOCKITO_JARS}"
       APPEND_LIBRARY_DIRS
       "${_deps_library_dirs}"
     )

--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -190,6 +190,36 @@ if(BUILD_TESTING)
   find_package(std_msgs REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  # Find mockito and it's dependencies
+  # TODO(jacobperron): Wrap this into cmake helper
+  find_jar(MOCKITO_JAR NAME mockito-core)
+  find_jar(BYTE_BUDDY_JAR NAME byte-buddy)
+  find_jar(BYTE_BUDDY_AGENT_JAR NAME byte-buddy-agent)
+  find_jar(OBJENESIS_JAR NAME objenesis)
+
+  if(NOT MOCKITO_JAR)
+    message(FATAL_ERROR "mockito installation not found")
+  endif()
+
+  if(NOT BYTE_BUDDY_JAR)
+    message(FATAL_ERROR "byte-buddy installation not found (mockito dependency)")
+  endif()
+
+  if(NOT BYTE_BUDDY_AGENT_JAR)
+    message(FATAL_ERROR "byte-buddy-agent installation not found (mockito dependency)")
+  endif()
+
+  if(NOT OBJENESIS_JAR)
+    message(FATAL_ERROR "objenesis installation not found (mockito dependency)")
+  endif()
+
+  set(MOCKITO_JARS
+    "${MOCKITO_JAR}"
+    "${BYTE_BUDDY_JAR}"
+    "${BYTE_BUDDY_AGENT_JAR}"
+    "${OBJENESIS_JAR}"
+  )
+
   set(${PROJECT_NAME}_message_files
     "msg/BoundedArrayNested.msg"
     "msg/BoundedArrayPrimitives.msg"
@@ -243,6 +273,7 @@ if(BUILD_TESTING)
     # "src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java"
     "src/test/java/org/ros2/rcljava/publisher/PublisherTest.java"
     "src/test/java/org/ros2/rcljava/subscription/SubscriptionTest.java"
+    "src/test/java/org/ros2/rcljava/time/TimeSourceTest.java"
     "src/test/java/org/ros2/rcljava/timer/TimerTest.java"
   )
 
@@ -258,6 +289,7 @@ if(BUILD_TESTING)
     # "org.ros2.rcljava.parameters.SyncParametersClientTest"
     "org.ros2.rcljava.publisher.PublisherTest"
     "org.ros2.rcljava.subscription.SubscriptionTest"
+    "org.ros2.rcljava.time.TimeSourceTest"
     "org.ros2.rcljava.timer.TimerTest"
   )
 
@@ -330,6 +362,7 @@ if(BUILD_TESTING)
       "${rosgraph_msgs_JARS}"
       "${_${PROJECT_NAME}_jar_file}"
       "${_${PROJECT_NAME}_messages_jar_file}"
+      "${MOCKITO_JARS}"
       APPEND_LIBRARY_DIRS
       "${_deps_library_dirs}"
     )

--- a/rcljava/package.xml
+++ b/rcljava/package.xml
@@ -40,7 +40,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>builtin_interfaces</test_depend>
-  <test_depend>libmockito-java</test_depend>
+  <test_depend>mockito_vendor</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>rcljava_common</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>

--- a/rcljava/package.xml
+++ b/rcljava/package.xml
@@ -40,6 +40,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>builtin_interfaces</test_depend>
+  <test_depend>libmockito-java</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>rcljava_common</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>

--- a/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/time/TimeSource.java
@@ -131,7 +131,7 @@ public final class TimeSource {
         for (ParameterVariant param : parameters) {
           if (param.getName() == "use_sim_time") {
             if (param.getType() == ParameterType.PARAMETER_BOOL) {
-              this.timeSource.rosTimeIsActive = param.asBool();
+              this.timeSource.setRosTimeIsActive(param.asBool());
             } else {
               result.setSuccessful(false);
               result.setReason("'use_sim_time' parameter must be a boolean");

--- a/rcljava/src/test/java/org/ros2/rcljava/time/TimeSourceTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/time/TimeSourceTest.java
@@ -15,31 +15,36 @@
 
 package org.ros2.rcljava.time;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-// import static org.mockito.Mockito;
+import org.junit.runner.RunWith;
+
 import static org.mockito.Mockito.*;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.ros2.rcljava.consumers.Consumer;
-import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.node.Node;
-import org.ros2.rcljava.parameters.ParameterType;
 import org.ros2.rcljava.parameters.ParameterVariant;
 import org.ros2.rcljava.subscription.Subscription;
 import org.ros2.rcljava.time.TimeSource;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class TimeSourceTest {
+  @Mock
   private Node mockedNode;
+
+  @Mock
+  private Clock mockedClock;
+
+  @Mock
+  private Subscription mockSubscription;
 
   @BeforeClass
   public static void setupOnce() throws Exception {
@@ -52,11 +57,6 @@ public class TimeSourceTest {
   @AfterClass
   public static void tearDownOnce() {
     RCLJava.shutdown();
-  }
-
-  @Before
-  public void setUp() {
-    mockedNode = mock(Node.class);
   }
 
   @Test
@@ -122,7 +122,6 @@ public class TimeSourceTest {
 
   @Test
   public final void testAttachClock() {
-    Clock mockedClock = mock(Clock.class);
     when(mockedClock.getClockType()).thenReturn(ClockType.ROS_TIME);
 
     TimeSource timeSource = new TimeSource();
@@ -137,15 +136,12 @@ public class TimeSourceTest {
 
   @Test(expected = IllegalArgumentException.class)
   public final void testAttachClockInvalidType() {
-    Clock mockedClock = mock(Clock.class);
-
     TimeSource timeSource = new TimeSource();
     timeSource.attachClock(mockedClock);
   }
 
   @Test
   public final void testDetachClock() {
-    Clock mockedClock = mock(Clock.class);
     when(mockedClock.getClockType()).thenReturn(ClockType.ROS_TIME);
 
     TimeSource timeSource = new TimeSource();
@@ -169,7 +165,6 @@ public class TimeSourceTest {
   @Test
   public final void testSetRosTimeIsActiveWithNode() {
     when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", false));
-    Subscription mockSubscription = mock(Subscription.class);
     when(mockedNode.createSubscription(eq(rosgraph_msgs.msg.Clock.class), anyString(), any(Consumer.class)))
       .thenReturn(mockSubscription);
 

--- a/rcljava/src/test/java/org/ros2/rcljava/time/TimeSourceTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/time/TimeSourceTest.java
@@ -1,0 +1,188 @@
+/* Copyright 2020 Open Source Robotics Foundation, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava.time;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+// import static org.mockito.Mockito;
+import static org.mockito.Mockito.*;
+
+import org.ros2.rcljava.consumers.Consumer;
+import org.ros2.rcljava.interfaces.MessageDefinition;
+import org.ros2.rcljava.RCLJava;
+import org.ros2.rcljava.node.Node;
+import org.ros2.rcljava.parameters.ParameterType;
+import org.ros2.rcljava.parameters.ParameterVariant;
+import org.ros2.rcljava.subscription.Subscription;
+import org.ros2.rcljava.time.TimeSource;
+
+public class TimeSourceTest {
+  private Node mockedNode;
+
+  @BeforeClass
+  public static void setupOnce() throws Exception {
+    // Just to quiet down warnings
+    org.apache.log4j.BasicConfigurator.configure();
+
+    RCLJava.rclJavaInit();
+  }
+
+  @AfterClass
+  public static void tearDownOnce() {
+    RCLJava.shutdown();
+  }
+
+  @Before
+  public void setUp() {
+    mockedNode = mock(Node.class);
+  }
+
+  @Test
+  public final void testEmptyConstructor() {
+    TimeSource timeSource = new TimeSource();
+    assertFalse(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testConstructorWithNode() {
+    when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", false));
+
+    TimeSource timeSource = new TimeSource(mockedNode);
+    assertFalse(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testAttachNodeUseSimTimeFalse() {
+    when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", false));
+
+    TimeSource timeSource = new TimeSource();
+    timeSource.attachNode(mockedNode);
+    assertFalse(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testAttachNodeUseSimTimeTrue() {
+    when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", true));
+
+    TimeSource timeSource = new TimeSource();
+    timeSource.attachNode(mockedNode);
+    assertTrue(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testAttachNodeTwice() {
+    when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", true));
+
+    TimeSource timeSource = new TimeSource();
+    timeSource.attachNode(mockedNode);
+    assertTrue(timeSource.getRosTimeIsActive());
+
+    // Attach the same node again
+    timeSource.attachNode(mockedNode);
+    assertTrue(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testDetachNode() {
+    when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", true));
+
+    // Attaches node with ROS time active
+    TimeSource timeSource = new TimeSource(mockedNode);
+    assertTrue(timeSource.getRosTimeIsActive());
+
+    timeSource.detachNode();
+    assertFalse(timeSource.getRosTimeIsActive());
+
+    // Calling detach again shouldn't change anything
+    timeSource.detachNode();
+    assertFalse(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testAttachClock() {
+    Clock mockedClock = mock(Clock.class);
+    when(mockedClock.getClockType()).thenReturn(ClockType.ROS_TIME);
+
+    TimeSource timeSource = new TimeSource();
+    // Attaching a clock should notifiy the clock
+    timeSource.attachClock(mockedClock);
+    verify(mockedClock).setRosTimeIsActive(false);
+
+    // Setting ROS time active should notify clock
+    timeSource.setRosTimeIsActive(true);
+    verify(mockedClock).setRosTimeIsActive(true);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public final void testAttachClockInvalidType() {
+    Clock mockedClock = mock(Clock.class);
+
+    TimeSource timeSource = new TimeSource();
+    timeSource.attachClock(mockedClock);
+  }
+
+  @Test
+  public final void testDetachClock() {
+    Clock mockedClock = mock(Clock.class);
+    when(mockedClock.getClockType()).thenReturn(ClockType.ROS_TIME);
+
+    TimeSource timeSource = new TimeSource();
+    timeSource.attachClock(mockedClock);
+    timeSource.detachClock(mockedClock);
+
+    // Setting ROS time active should not notify a detached clock
+    timeSource.setRosTimeIsActive(true);
+    verify(mockedClock, never()).setRosTimeIsActive(true);
+  }
+
+  @Test
+  public final void testSetRosTimeIsActiveNoNode() {
+    TimeSource timeSource = new TimeSource();
+    timeSource.setRosTimeIsActive(false);
+    assertFalse(timeSource.getRosTimeIsActive());
+    timeSource.setRosTimeIsActive(true);
+    assertTrue(timeSource.getRosTimeIsActive());
+  }
+
+  @Test
+  public final void testSetRosTimeIsActiveWithNode() {
+    when(mockedNode.getParameter("use_sim_time")).thenReturn(new ParameterVariant("use_sim_time", false));
+    Subscription mockSubscription = mock(Subscription.class);
+    when(mockedNode.createSubscription(eq(rosgraph_msgs.msg.Clock.class), anyString(), any(Consumer.class)))
+      .thenReturn(mockSubscription);
+
+    TimeSource timeSource = new TimeSource(mockedNode);
+    timeSource.setRosTimeIsActive(false);
+    assertFalse(timeSource.getRosTimeIsActive());
+    timeSource.setRosTimeIsActive(true);
+    assertTrue(timeSource.getRosTimeIsActive());
+    // Expect subscription for the "/clock" topic when set active
+    verify(mockedNode).createSubscription(eq(rosgraph_msgs.msg.Clock.class), eq("/clock"), any(Consumer.class));
+    timeSource.setRosTimeIsActive(false);
+    assertFalse(timeSource.getRosTimeIsActive());
+    // Expect subscription removed when set not active
+    verify(mockedNode).removeSubscription(any(Subscription.class));
+  }
+}

--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -22,7 +22,7 @@ repositories:
   ros2_java/mockito_vendor:
     type: git
     url: https://github.com/ros2-java/mockito_vendor.git
-    version: add_package
+    version: main
   ros2_java/ros2_java:
     type: git
     url: https://github.com/osrf/ros2_java.git

--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs
     version: master
+  ros2_java/mockito_vendor:
+    type: git
+    url: https://github.com/ros2-java/mockito_vendor.git
+    version: add_package
   ros2_java/ros2_java:
     type: git
     url: https://github.com/osrf/ros2_java.git


### PR DESCRIPTION
Also fixed what I think was a bug in ca0a225.

This change introduces a new dependency [mockito](https://site.mockito.org/), which I think is super useful for writing tests with mock objects. I've proposed a rosdep rule for it in https://github.com/ros/rosdistro/pull/26308.
Note, if we want to eventually support Windows, we'll have to investigate installing the jars for mockito and its dependencies (perhaps like [how we handle JUnit](https://github.com/ros2-java/ros2_java/blob/62918477f4fb8810d4df0ac9c9e67b885b635d01/rcljava_common/cmake/Modules/JavaExtra.cmake#L60-L72)).

@ivanpauno 
I first wanted to get your thoughts on introducing this dependency before putting more effort into supporting Windows and resolving the TODO in the CMakeLists.txt.