### PR TITLE
Remove dependency on opensplice

### DIFF
--- a/rosidl_generator_java/package.xml
+++ b/rosidl_generator_java/package.xml
@@ -46,7 +46,6 @@
   <test_depend>rosidl_typesupport_connext_c</test_depend>
   <test_depend>rosidl_typesupport_fastrtps_c</test_depend>
   <test_depend>rosidl_typesupport_introspection_c</test_depend>
-  <test_depend>rosidl_typesupport_opensplice_c</test_depend>
   <test_depend>test_interface_files</test_depend>
 
   <member_of_group>rosidl_generator_packages</member_of_group>


### PR DESCRIPTION
Opensplice is not distributed with ROS 2 since Foxy.