### PR TITLE
Enable and fix AsyncParametersClientTest

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -289,6 +289,7 @@ if(BUILD_TESTING)
     "org.ros2.rcljava.node.NodeParametersTest"
     "org.ros2.rcljava.node.NodeUndeclaredParametersTest"
     "org.ros2.rcljava.node.NodeTest"
+    "org.ros2.rcljava.parameters.AsyncParametersClientTest"
     "org.ros2.rcljava.parameters.SyncParametersClientTest"
     "org.ros2.rcljava.publisher.PublisherTest"
     "org.ros2.rcljava.qos.QoSProfileTest"

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -107,8 +107,14 @@ public class AsyncParametersClientTest {
     List<String> parameterNames =
         Arrays.asList(new String[] {"foo", "bar", "baz", "foo.first", "foo.second", "foobar"});
 
+    List<rcl_interfaces.msg.SetParametersResult> setParametersResults = future.get();
+    assertEquals(6, setParametersResults.size());
+    for (rcl_interfaces.msg.SetParametersResult result : setParametersResults) {
+      assertEquals(true, result.getSuccessful());
+    }
+
     List<ParameterVariant> results = node.getParameters(parameterNames);
-    assertEquals(parameters, future.get());
+    assertEquals(parameters, results);
   }
 
   @Test


### PR DESCRIPTION
Now we're actually running the tests.

This also fixes a bug where we were comparing the wrong objects in one of the tests.