### PR TITLE
Fixes sources jar path

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -234,6 +234,8 @@ add_source_jar("${PROJECT_NAME}-source_jar"
   ${${PROJECT_NAME}_sources}
   OUTPUT_NAME
   ${PROJECT_NAME}-source
+  JAR_ROOT_PATH
+  "src/main/java/"
 )
 
 install_jar("${PROJECT_NAME}-source_jar" "share/${PROJECT_NAME}/java")

--- a/rcljava_common/cmake/Modules/JavaExtra.cmake
+++ b/rcljava_common/cmake/Modules/JavaExtra.cmake
@@ -180,7 +180,7 @@ function(add_source_jar _TARGET_NAME)
 
   cmake_parse_arguments(_add_source_jar
     ""
-    "OUTPUT_NAME"
+    "OUTPUT_NAME;JAR_ROOT_PATH"
     "SOURCES"
     ${ARGN}
   )
@@ -192,10 +192,16 @@ function(add_source_jar _TARGET_NAME)
   set(_SOURCE_FILES ${_add_source_jar_SOURCES} ${_add_source_jar_UNPARSED_ARGUMENTS})
   set(_JAVA_JAR_SOURCES_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_add_source_jar_OUTPUT_NAME}.jar)
 
+  set(_FIXED_PATH_FILES)
+  foreach(_SOURCE_FILE IN LISTS _SOURCE_FILES)
+    string(REPLACE ${_add_source_jar_JAR_ROOT_PATH} "" _FIXED_PATH_FILE ${_SOURCE_FILE})
+    list(APPEND _FIXED_PATH_FILES ${_FIXED_PATH_FILE})
+  endforeach()
+
   add_custom_command(
     OUTPUT ${_add_source_jar_OUTPUT_NAME}
-    COMMAND ${Java_JAR_EXECUTABLE} -cf ${_JAVA_JAR_SOURCES_OUTPUT} ${_SOURCE_FILES}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND ${Java_JAR_EXECUTABLE} -cf ${_JAVA_JAR_SOURCES_OUTPUT} ${_FIXED_PATH_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_add_source_jar_JAR_ROOT_PATH}
   )
   add_custom_target(${_TARGET_NAME} ALL DEPENDS ${_add_source_jar_OUTPUT_NAME})
 


### PR DESCRIPTION
If you look at the compiled jar their internal paths have the form: org.ros2.rcljava.*. While the sources jar has an internal path that starts in ${CMAKE_CURRENT_SOURCE_DIR}.
This is an attempt to fix that


Signed-off-by: Gonzalo de Pedro <gonzalo@depedro.com.ar>