### PR TITLE
Add transition from accepted to executing in the action server

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/action/ActionServerGoalHandle.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/action/ActionServerGoalHandle.java
@@ -41,6 +41,13 @@ public interface ActionServerGoalHandle<T extends ActionDefinition> extends Disp
   public boolean isCanceling();
 
   /**
+   * Transition the goal to the EXECUTING state.
+   *
+   * Pre-condition: the goal must be in the ACCEPTED state.
+   */
+  public void execute();
+
+  /**
    * Transition the goal to the SUCCEEDED state.
    *
    * Pre-condition: the goal must be in the EXECUTING or CANCELING state.

--- a/rcljava/src/main/java/org/ros2/rcljava/action/GoalCallback.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/action/GoalCallback.java
@@ -20,7 +20,8 @@ import org.ros2.rcljava.interfaces.GoalRequestDefinition;
 public interface GoalCallback<T extends GoalRequestDefinition> {
   public enum GoalResponse {
     REJECT,
-    ACCEPT,
+    ACCEPT_AND_EXECUTE,
+    ACCEPT_AND_DEFER,
   };
 
   /**

--- a/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
@@ -152,7 +152,7 @@ public interface Node extends Disposable {
    * @param goalCallback The callback that will be called when the @{link ActionServer}
    *     receives a new goal request.
    * @param cancelCallback The callback that will be called when the @{link ActionServer}
-   *     receives a cancle request for an active goal.
+   *     receives a cancel request for an active goal.
    * @param acceptedCallback The callback that will be called when the @{link ActionServer}
    *     accepts a goal request.
    */

--- a/rcljava/src/test/java/org/ros2/rcljava/action/ActionServerTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/action/ActionServerTest.java
@@ -41,14 +41,13 @@ public class ActionServerTest {
     public test_msgs.action.Fibonacci_Goal goal;
     public GoalResponse handleGoal(test_msgs.action.Fibonacci.SendGoalRequest goal) {
       this.goal = goal.getGoal();
-      return GoalResponse.ACCEPT;
+      return GoalResponse.ACCEPT_AND_EXECUTE;
     }
   }
 
   class MockCancelCallback implements CancelCallback<test_msgs.action.Fibonacci> {
     public ActionServerGoalHandle<test_msgs.action.Fibonacci> goalHandle;
     public CancelResponse handleCancel(ActionServerGoalHandle<test_msgs.action.Fibonacci> goalHandle) {
-      this.goalHandle = goalHandle;
       return CancelResponse.ACCEPT;
     }
   }

--- a/rcljava/src/test/java/org/ros2/rcljava/action/ActionServerTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/action/ActionServerTest.java
@@ -48,6 +48,7 @@ public class ActionServerTest {
   class MockCancelCallback implements CancelCallback<test_msgs.action.Fibonacci> {
     public ActionServerGoalHandle<test_msgs.action.Fibonacci> goalHandle;
     public CancelResponse handleCancel(ActionServerGoalHandle<test_msgs.action.Fibonacci> goalHandle) {
+      this.goalHandle = goalHandle;
       return CancelResponse.ACCEPT;
     }
   }


### PR DESCRIPTION
* Add ACCEPT_AND_EXECUTE/ACCEPT_AND_DEFER to the result of the goal callback
* Transition from accepted to executing if ACCEPT_AND_EXECUTE was returned.

This is one of the things missing in the action server implementation.