### PR TITLE
Fix source 6 warnings

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -38,7 +38,9 @@ if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "6" "-Xlint:-options")
+if (NOT CMAKE_JAVA_COMPILE_FLAGS)
+  set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-Xlint:-options")
+endif()
 
 include_directories(include)
 

--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-target" "1.6")
+set(CMAKE_JAVA_COMPILE_FLAGS "-source" "6" "-Xlint:-options")
 
 include_directories(include)
 

--- a/rcljava_common/CMakeLists.txt
+++ b/rcljava_common/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-target" "1.6")
+set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-Xlint:-options")
 
 set(${PROJECT_NAME}_java_sources
   "src/main/java/org/ros2/rcljava/common/JNIUtils.java"

--- a/rcljava_common/CMakeLists.txt
+++ b/rcljava_common/CMakeLists.txt
@@ -31,7 +31,9 @@ if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-Xlint:-options")
+if (NOT CMAKE_JAVA_COMPILE_FLAGS)
+  set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.6" "-Xlint:-options")
+endif()
 
 set(${PROJECT_NAME}_java_sources
   "src/main/java/org/ros2/rcljava/common/JNIUtils.java"


### PR DESCRIPTION
We are currently seeing this warning:

```
--- stderr: rcljava_common                                                                                                                                                               
warning: [options] bootstrap class path not set in conjunction with -source 6                                                                                                         
warning: [options] source value 6 is obsolete and will be removed in a future release                                                                                                
warning: [options] target value 1.6 is obsolete and will be removed in a future release                                                                                                 
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.                                                                                                         
4 warnings                                                                                                                                                                            
---
```

Specifying source compatibility with java 6 is deprecated in the target we're building, the only way to ignore the warning is passing `-Xlint:-options` (or not pass `-source 1.6` at all).

I don't think we really need to pass `-target 1.6`, except if we want to generate classes files specific for that VM version for some reason.
IIUC, we only want to check source compatibility with java 6 to ensure android compatibility.

I don't understand this warning to be honest.

> warning: [options] bootstrap class path not set in conjunction with -source 6                                                                                                         

AFAIK, passing `-source 6` without passing a bootstrap path should be fine.

---

If we don't have any preference of which version of java to use, I would:

- Remove CMAKE_JAVA_COMPILE_FLAGS from the CMakeLists.txt files, that will use the latest java version if `CMAKE_JAVA_COMPILE_FLAGS` is not externally set.
- Specify a minimum version of [java when doing find_package](https://cmake.org/cmake/help/latest/module/FindJava.html).
- Set `CMAKE_JAVA_COMPILE_FLAGS` to `-source 1.6 -Xlint:-options` in CI so we ensure java 6 compatibility in the codebase.