### PR TITLE
Fix MessageLost native methods names causing loading issues

### DIFF
--- a/rcljava/src/main/cpp/org_ros2_rcljava_subscription_statuses_MessageLost.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_subscription_statuses_MessageLost.cpp
@@ -24,7 +24,7 @@
 using rcljava_common::exceptions::rcljava_throw_exception;
 
 JNIEXPORT jlong JNICALL
-Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeAllocateRCL(
+Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeAllocateRCLStatusEvent(
   JNIEnv * env, jclass)
 {
   void * p = malloc(sizeof(rmw_message_lost_status_t));
@@ -36,14 +36,14 @@ Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeAllocateRCL(
 }
 
 JNIEXPORT void JNICALL
-Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeDeallocateRCL(
+Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeDeallocateRCLStatusEvent(
   JNIEnv *, jclass, jlong handle)
 {
   free(reinterpret_cast<void *>(handle));
 }
 
 JNIEXPORT void JNICALL
-Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeFromRCL(
+Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeFromRCLEvent(
   JNIEnv * env, jobject self, jlong handle)
 {
   auto * p = reinterpret_cast<rmw_message_lost_status_t *>(handle);
@@ -67,7 +67,7 @@ Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeFromRCL(
 }
 
 JNIEXPORT jint JNICALL
-Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeGetEventType(
+Java_org_ros2_rcljava_subscription_statuses_MessageLost_nativeGetSubscriptionEventType(
   JNIEnv *, jclass)
 {
   return RCL_SUBSCRIPTION_MESSAGE_LOST;

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/statuses/MessageLost.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/statuses/MessageLost.java
@@ -30,16 +30,16 @@ public class MessageLost implements SubscriptionEventStatus {
   public int totalCountChange;
 
   public final long allocateRCLStatusEvent() {
-    return nativeAllocateRCL();
+    return nativeAllocateRCLStatusEvent();
   }
   public final void deallocateRCLStatusEvent(long handle) {
-    nativeDeallocateRCL(handle);
+    nativeDeallocateRCLStatusEvent(handle);
   }
   public final void fromRCLEvent(long handle) {
-    nativeFromRCL(handle);
+    nativeFromRCLEvent(handle);
   }
   public final int getSubscriptionEventType() {
-    return nativeGetEventType();
+    return nativeGetSubscriptionEventType();
   }
   // TODO(ivanpauno): Remove this when -source 8 can be used (method references for the win)
   public static final Supplier<MessageLost> factory = new Supplier<MessageLost>() {
@@ -47,6 +47,11 @@ public class MessageLost implements SubscriptionEventStatus {
       return new MessageLost();
     }
   };
+
+  private static native long nativeAllocateRCLStatusEvent();
+  private static native void nativeDeallocateRCLStatusEvent(long handle);
+  private native void nativeFromRCLEvent(long handle);
+  private static native int nativeGetSubscriptionEventType();
 
   private static final Logger logger = LoggerFactory.getLogger(MessageLost.class);
   static {
@@ -57,9 +62,4 @@ public class MessageLost implements SubscriptionEventStatus {
       System.exit(1);
     }
   }
-
-  private static native long nativeAllocateRCL();
-  private static native void nativeDeallocateRCL(long handle);
-  private native void nativeFromRCL(long handle);
-  private static native int nativeGetEventType();
 }


### PR DESCRIPTION
This should fix the last CI test failure :crossed_fingers:

I probably broke the names before merging the original PR ...
I'm not sure what happened here