### PR TITLE
Add methods to create a parameter client in Node

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/client/Client.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/client/Client.java
@@ -26,9 +26,7 @@ import org.ros2.rcljava.interfaces.ServiceDefinition;
 import org.ros2.rcljava.service.RMWRequestId;
 
 public interface Client<T extends ServiceDefinition> extends Disposable {
-  <U extends MessageDefinition> Class<U> getRequestType();
-
-  <U extends MessageDefinition> Class<U> getResponseType();
+  ServiceDefinition getServiceDefinition();
 
   <U extends MessageDefinition> void handleResponse(RMWRequestId header, U response);
 

--- a/rcljava/src/main/java/org/ros2/rcljava/client/ClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/client/ClientImpl.java
@@ -55,18 +55,23 @@ public class ClientImpl<T extends ServiceDefinition> implements Client<T> {
   private final String serviceName;
   private Map<Long, Map.Entry<Consumer, RCLFuture>> pendingRequests;
 
-  private final Class<MessageDefinition> requestType;
-  private final Class<MessageDefinition> responseType;
+  private final ServiceDefinition serviceDefinition;
 
-  public ClientImpl(final WeakReference<Node> nodeReference, final long handle,
-      final String serviceName, final Class<MessageDefinition> requestType,
-      final Class<MessageDefinition> responseType) {
+  public ClientImpl(
+    final ServiceDefinition serviceDefinition,
+    final WeakReference<Node> nodeReference,
+    final long handle,
+    final String serviceName)
+  {
     this.nodeReference = nodeReference;
     this.handle = handle;
     this.serviceName = serviceName;
-    this.requestType = requestType;
-    this.responseType = responseType;
+    this.serviceDefinition = serviceDefinition;
     this.pendingRequests = new HashMap<Long, Map.Entry<Consumer, RCLFuture>>();
+  }
+
+  public ServiceDefinition getServiceDefinition() {
+    return this.serviceDefinition;
   }
 
   public final <U extends MessageDefinition, V extends MessageDefinition> Future<V>
@@ -111,14 +116,6 @@ public class ClientImpl<T extends ServiceDefinition> implements Client<T> {
   private static native long nativeSendClientRequest(
       long handle, long requestFromJavaConverterHandle, long requestDestructorHandle,
       MessageDefinition requestMessage);
-
-  public final Class<MessageDefinition> getRequestType() {
-    return this.requestType;
-  }
-
-  public final Class<MessageDefinition> getResponseType() {
-    return this.responseType;
-  }
 
   /**
    * Destroy a ROS2 client (rcl_client_t).

--- a/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
@@ -126,23 +126,24 @@ public interface Node extends Disposable {
   <T extends MessageDefinition> Publisher<T> createPublisher(
       final Class<T> messageType, final String topic);
 
-  <T extends ServiceDefinition> Service<T> createService(final Class<T> serviceType,
+  <T extends ServiceDefinition> Service<T> createService(
+      final Class<T> serviceType,
       final String serviceName,
       final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition>
           callback,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException;
+      final QoSProfile qosProfile);
 
-  <T extends ServiceDefinition> Service<T> createService(final Class<T> serviceType,
+  <T extends ServiceDefinition> Service<T> createService(
+      final Class<T> serviceType,
       final String serviceName,
       final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition>
-          callback) throws NoSuchFieldException, IllegalAccessException;
+          callback);
 
   <T extends ServiceDefinition> Client<T> createClient(
-      final Class<T> serviceType, final String serviceName, final QoSProfile qosProfile)
-      throws NoSuchFieldException, IllegalAccessException;
+      final Class<T> serviceType, final String serviceName, final QoSProfile qosProfile);
 
-  <T extends ServiceDefinition> Client<T> createClient(final Class<T> serviceType,
-      final String serviceName) throws NoSuchFieldException, IllegalAccessException;
+  <T extends ServiceDefinition> Client<T> createClient(
+      final Class<T> serviceType, final String serviceName);
 
   /**
    * Create an ActionServer&lt;T&gt;.

--- a/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
@@ -39,6 +39,8 @@ import org.ros2.rcljava.interfaces.ServiceDefinition;
 import org.ros2.rcljava.parameters.ParameterCallback;
 import org.ros2.rcljava.parameters.ParameterType;
 import org.ros2.rcljava.parameters.ParameterVariant;
+import org.ros2.rcljava.parameters.client.AsyncParametersClient;
+import org.ros2.rcljava.parameters.client.SyncParametersClient;
 import org.ros2.rcljava.publisher.Publisher;
 import org.ros2.rcljava.qos.QoSProfile;
 import org.ros2.rcljava.service.RMWRequestId;
@@ -263,6 +265,16 @@ public interface Node extends Disposable {
    * @return The namespace of the node.
    */
   String getNamespace();
+
+  /**
+   * Create an asynchronous parameter client.
+   */
+  AsyncParametersClient createAsyncParametersClient(String nodeName);
+
+  /**
+   * Create an synchronous parameter client.
+   */
+  SyncParametersClient createSyncParametersClient(String nodeName);
 
   /**
    * Declare and initialize a parameter, return the effective value.

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -44,6 +44,10 @@ import org.ros2.rcljava.parameters.ParameterCallback;
 import org.ros2.rcljava.parameters.ParameterNotDeclaredException;
 import org.ros2.rcljava.parameters.ParameterType;
 import org.ros2.rcljava.parameters.ParameterVariant;
+import org.ros2.rcljava.parameters.client.AsyncParametersClient;
+import org.ros2.rcljava.parameters.client.AsyncParametersClientImpl;
+import org.ros2.rcljava.parameters.client.SyncParametersClient;
+import org.ros2.rcljava.parameters.client.SyncParametersClientImpl;
 import org.ros2.rcljava.parameters.service.ParameterService;
 import org.ros2.rcljava.parameters.service.ParameterServiceImpl;
 import org.ros2.rcljava.publisher.Publisher;
@@ -531,6 +535,14 @@ public class NodeImpl implements Node {
 
   public final String getNamespace() {
     return nativeGetNamespace(this.handle);
+  }
+
+  public AsyncParametersClient createAsyncParametersClient(String nodeName) {
+    return new AsyncParametersClientImpl(this, nodeName);
+  }
+
+  public SyncParametersClient createSyncParametersClient(String nodeName) {
+    return new SyncParametersClientImpl(this, nodeName);
   }
 
   public ParameterVariant declareParameter(ParameterVariant parameter) {

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -49,7 +49,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
   private final Client<rcl_interfaces.srv.DescribeParameters> describeParametersClient;
 
   public AsyncParametersClientImpl(final Node node, final String remoteName,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+      final QoSProfile qosProfile) {
     this.node = node;
     if (remoteName != "") {
       this.remoteName = remoteName;
@@ -84,17 +84,17 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
   }
 
   public AsyncParametersClientImpl(final Node node, final QoSProfile qosProfile)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(node, "", qosProfile);
   }
 
   public AsyncParametersClientImpl(final Node node, final String remoteName)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(node, remoteName, QoSProfile.PARAMETERS);
   }
 
   public AsyncParametersClientImpl(final Node node)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(node, "", QoSProfile.PARAMETERS);
   }
 

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
@@ -55,44 +55,55 @@ public class SyncParametersClientImpl implements SyncParametersClient {
 
   public AsyncParametersClient asyncParametersClient;
 
-  public SyncParametersClientImpl(final Node node, final String remoteName,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+  public SyncParametersClientImpl(
+    final Node node,
+    final String remoteName,
+    final QoSProfile qosProfile)
+  {
     this.asyncParametersClient = new AsyncParametersClientImpl(node, remoteName, qosProfile);
   }
 
   public SyncParametersClientImpl(final Node node, final QoSProfile qosProfile)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(node, "", qosProfile);
   }
 
   public SyncParametersClientImpl(final Node node, final String remoteName)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(node, remoteName, QoSProfile.PARAMETERS);
   }
 
   public SyncParametersClientImpl(final Node node)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(node, "", QoSProfile.PARAMETERS);
   }
 
-  public SyncParametersClientImpl(final Executor executor, final Node node, final String remoteName,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+  public SyncParametersClientImpl(
+    final Executor executor,
+    final Node node,
+    final String remoteName,
+    final QoSProfile qosProfile)
+  {
     this.executor = executor;
     this.asyncParametersClient = new AsyncParametersClientImpl(node, remoteName, qosProfile);
   }
 
-  public SyncParametersClientImpl(final Executor executor, final Node node,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+  public SyncParametersClientImpl(
+    final Executor executor,
+    final Node node,
+    final QoSProfile qosProfile)
+  {
     this(executor, node, "", qosProfile);
   }
 
-  public SyncParametersClientImpl(final Executor executor, final Node node, final String remoteName)
-      throws NoSuchFieldException, IllegalAccessException {
+  public SyncParametersClientImpl(
+    final Executor executor, final Node node, final String remoteName)
+  {
     this(executor, node, remoteName, QoSProfile.PARAMETERS);
   }
 
   public SyncParametersClientImpl(final Executor executor, final Node node)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this(executor, node, "", QoSProfile.PARAMETERS);
   }
 

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
@@ -38,7 +38,7 @@ public class ParameterServiceImpl implements ParameterService {
   Service<rcl_interfaces.srv.ListParameters> listParametersService;
 
   public ParameterServiceImpl(final Node node, final QoSProfile qosProfile)
-      throws NoSuchFieldException, IllegalAccessException {
+  {
     this.node = node;
     this.getParametersService = node.<rcl_interfaces.srv.GetParameters>createService(
         rcl_interfaces.srv.GetParameters.class,
@@ -146,7 +146,7 @@ public class ParameterServiceImpl implements ParameterService {
         qosProfile);
   }
 
-  public ParameterServiceImpl(final Node node) throws NoSuchFieldException, IllegalAccessException {
+  public ParameterServiceImpl(final Node node) {
     this(node, QoSProfile.PARAMETERS);
   }
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/service/Service.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/service/Service.java
@@ -21,9 +21,7 @@ import org.ros2.rcljava.interfaces.MessageDefinition;
 import org.ros2.rcljava.interfaces.ServiceDefinition;
 
 public interface Service<T extends ServiceDefinition> extends Disposable {
-  <U extends MessageDefinition> Class<U> getRequestType();
-
-  <U extends MessageDefinition> Class<U> getResponseType();
+  ServiceDefinition getServiceDefinition();
 
   void executeCallback(RMWRequestId rmwRequestId, MessageDefinition request, MessageDefinition response);
 

--- a/rcljava/src/main/java/org/ros2/rcljava/service/ServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/service/ServiceImpl.java
@@ -45,28 +45,25 @@ public class ServiceImpl<T extends ServiceDefinition> implements Service<T> {
   private final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition>
       callback;
 
-  private final Class<MessageDefinition> requestType;
-  private final Class<MessageDefinition> responseType;
+  private final ServiceDefinition serviceDefinition;
 
-  public ServiceImpl(final WeakReference<Node> nodeReference, final long handle,
-      final String serviceName,
-      final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition>
-          callback,
-      final Class<MessageDefinition> requestType, final Class<MessageDefinition> responseType) {
+  public ServiceImpl(
+    final ServiceDefinition serviceDefinition,
+    final WeakReference<Node> nodeReference,
+    final long handle,
+    final String serviceName,
+    final TriConsumer<RMWRequestId, ? extends MessageDefinition, ? extends MessageDefinition>
+      callback)
+  {
     this.nodeReference = nodeReference;
     this.handle = handle;
     this.serviceName = serviceName;
     this.callback = callback;
-    this.requestType = requestType;
-    this.responseType = responseType;
+    this.serviceDefinition = serviceDefinition;
   }
 
-  public final Class<MessageDefinition> getRequestType() {
-    return this.requestType;
-  }
-
-  public final Class<MessageDefinition> getResponseType() {
-    return this.responseType;
+  public final ServiceDefinition getServiceDefinition() {
+    return this.serviceDefinition;
   }
 
   /**

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java
@@ -15,4 +15,7 @@
 
 package org.ros2.rcljava.interfaces;
 
-public interface ServiceDefinition {}
+public interface ServiceDefinition {
+  MessageDefinition newRequestInstance();
+  MessageDefinition newResponseInstance();
+}

--- a/rosidl_generator_java/resource/srv.java.em
+++ b/rosidl_generator_java/resource/srv.java.em
@@ -61,6 +61,14 @@ public class @(type_name) implements ServiceDefinition {
     }
   }
 
+  public @(type_name)_Request newRequestInstance() {
+    return new @(type_name)_Request();
+  }
+
+  public @(type_name)_Response newResponseInstance() {
+    return new @(type_name)_Response();
+  }
+
   public static native long getServiceTypeSupport();
 
   public static final Class<@(type_name)_Request> RequestType = @(type_name)_Request.class;


### PR DESCRIPTION
Both classes are almost equivalent to the ones in `rclcpp`, the existing code also already had unit tests.

I think that it doesn't make much sense to have separated `AsyncParametersClient` and `SyncParametersClient` implementations, as the internal implementations is almost the same.
I would rather have only one `ParametersClient` class that has both sync and async methods, though it doesn't matter much.