### PR TITLE
Avoid blocking forever in RCLFuture.get() with timeout

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
@@ -287,21 +287,60 @@ public final class RCLJava {
     getGlobalExecutor().removeNode(composableNode);
   }
 
-  public static void spinOnce(final Node node) {
+  /**
+   * Execute one callback for a @{link Node}.
+   *
+   * Wait until a callback becomes ready and then execute it.
+   *
+   * @param node The node to spin on.
+   * @param timeout The time to wait for a callback to become ready in nanoseconds.
+   *   If a timeout occurs, then nothing happens and this method returns.
+   */
+  public static void spinOnce(final Node node, long timeout) {
     ComposableNode composableNode = new ComposableNode() {
       public Node getNode() {
         return node;
       }
     };
     getGlobalExecutor().addNode(composableNode);
-    getGlobalExecutor().spinOnce();
+    getGlobalExecutor().spinOnce(timeout);
     getGlobalExecutor().removeNode(composableNode);
   }
 
-  public static void spinOnce(final ComposableNode composableNode) {
+  /**
+   * Execute one callback for a @{link Node}.
+   *
+   * Wait until a callback becomes ready and then execute it.
+   *
+   * @param node The node to spin on.
+   */
+  public static void spinOnce(final Node node) {
+    RCLJava.spinOnce(node, -1);
+  }
+
+  /**
+   * Execute one callback for a @{link ComposableNode}.
+   *
+   * Wait until a callback becomes ready and then execute it.
+   *
+   * @param composableNode The composable node to spin on.
+   * @param timeout The time to wait for a callback to become ready in nanoseconds.
+   *   If a timeout occurs, then nothing happens and this method returns.
+   */
+  public static void spinOnce(final ComposableNode composableNode, long timeout) {
     getGlobalExecutor().addNode(composableNode);
-    getGlobalExecutor().spinOnce();
+    getGlobalExecutor().spinOnce(timeout);
     getGlobalExecutor().removeNode(composableNode);
+  }
+  /**
+   * Execute one callback for a @{link ComposableNode}.
+   *
+   * Wait until a callback becomes ready and then execute it.
+   *
+   * @param composableNode The composable node to spin on.
+   */
+  public static void spinOnce(final ComposableNode composableNode) {
+    RCLJava.spinOnce(composableNode, -1);
   }
 
   public static void spinSome(final Node node) {

--- a/rcljava/src/main/java/org/ros2/rcljava/concurrent/RCLFuture.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/concurrent/RCLFuture.java
@@ -73,13 +73,13 @@ public class RCLFuture<V> implements Future<V> {
 
     while (RCLJava.ok()) {
       if (executor != null) {
-        executor.spinOnce();
+        executor.spinOnce(timeoutNS);
       } else {
         Node node = nodeReference.get();
         if (node == null) {
           return null; // TODO(esteve) do something
         }
-        RCLJava.spinOnce(node);
+        RCLJava.spinOnce(node, timeoutNS);
       }
 
       if (isDone()) {


### PR DESCRIPTION
Add overloads for spinOnce methods to include a timeout argument and call this when spinning in the future.

This fixes a bug where the future.get(...) call blocks forever, e.g. when waiting on a service response and the service becomes unavailable.