### PR TITLE
Refactor future

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.ros2.rcljava.client.Client;
@@ -358,6 +359,34 @@ public final class RCLJava {
     getGlobalExecutor().addNode(composableNode);
     getGlobalExecutor().spinSome();
     getGlobalExecutor().removeNode(composableNode);
+  }
+
+  public static void spinUntilComplete(final Node node, final Future future, long timeoutNs) {
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+    RCLJava.spinUntilComplete(composableNode, future, timeoutNs);
+  }
+
+  public static void spinUntilComplete(final Node node, final Future future)
+  {
+    RCLJava.spinUntilComplete(node, future, -1);
+  }
+
+  public static void spinUntilComplete(
+    final ComposableNode node, final Future future, long timeoutNs)
+  {
+    getGlobalExecutor().addNode(node);
+    getGlobalExecutor().spinUntilComplete(future, timeoutNs);
+    getGlobalExecutor().removeNode(node);
+  }
+
+  public static void spinUntilComplete(
+    final ComposableNode node, final Future future)
+  {
+    RCLJava.spinUntilComplete(node, future, -1);
   }
 
   public static synchronized void shutdown() {

--- a/rcljava/src/main/java/org/ros2/rcljava/client/ClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/client/ClientImpl.java
@@ -87,7 +87,7 @@ public class ClientImpl<T extends ServiceDefinition> implements Client<T> {
       long sequenceNumber = nativeSendClientRequest(
           handle, request.getFromJavaConverterInstance(),
           request.getDestructorInstance(), request);
-      RCLFuture<V> future = new RCLFuture<V>(this.nodeReference);
+      RCLFuture<V> future = new RCLFuture<V>();
 
       Map.Entry<Consumer, RCLFuture> entry =
           new AbstractMap.SimpleEntry<Consumer, RCLFuture>(callback, future);

--- a/rcljava/src/main/java/org/ros2/rcljava/concurrent/RCLFuture.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/concurrent/RCLFuture.java
@@ -15,6 +15,7 @@
 
 package org.ros2.rcljava.concurrent;
 
+import java.lang.Deprecated;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -31,64 +32,61 @@ public class RCLFuture<V> implements Future<V> {
   private V value = null;
   private Executor executor = null;
 
+  public RCLFuture() {}
+
+  /**
+   * @deprecated nodeReference is not used, use constructor without arguments.
+   * @param nodeReference
+   */
+  @Deprecated
   public RCLFuture(final WeakReference<Node> nodeReference) {
     this.nodeReference = nodeReference;
   }
 
+  /**
+   * @deprecated executor is not used, use constructor without arguments.
+   * @param executor
+   */
+  @Deprecated
   public RCLFuture(final Executor executor) {
     this.executor = executor;
   }
 
-  public final V get() throws InterruptedException, ExecutionException {
+  public final synchronized V get() throws InterruptedException, ExecutionException {
     if(this.value != null) {
       return this.value;
     }
     while (RCLJava.ok() && !isDone()) {
-      if (executor != null) {
-        executor.spinOnce();
-      } else {
-        Node node = nodeReference.get();
-        if (node == null) {
-          return null; // TODO(esteve) do something
-        }
-        RCLJava.spinOnce(node);
-      }
+      this.wait();
     }
     return this.value;
   }
 
-  public final V get(final long timeout, final TimeUnit unit)
+  public final synchronized V get(final long timeout, final TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
     if (isDone()) {
       return value;
     }
 
-    long endTime = TimeUnit.NANOSECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-
-    long timeoutNS = TimeUnit.NANOSECONDS.convert(timeout, unit);
+    long endTime = System.nanoTime();
+    long timeoutNS = unit.toNanos(timeout);
 
     if (timeoutNS > 0) {
       endTime += timeoutNS;
     }
 
     while (RCLJava.ok()) {
-      if (executor != null) {
-        executor.spinOnce(timeoutNS);
-      } else {
-        Node node = nodeReference.get();
-        if (node == null) {
-          return null; // TODO(esteve) do something
-        }
-        RCLJava.spinOnce(node, timeoutNS);
-      }
+      this.wait(TimeUnit.NANOSECONDS.toMillis(timeoutNS), (int) (timeoutNS % 1000000l));
 
       if (isDone()) {
         return value;
       }
 
-      long now = TimeUnit.NANOSECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      long now = System.nanoTime();
       if (now >= endTime) {
         throw new TimeoutException();
+      } else {
+        timeoutNS = endTime - now;
       }
     }
     throw new InterruptedException();
@@ -109,5 +107,6 @@ public class RCLFuture<V> implements Future<V> {
   public final synchronized void set(final V value) {
     this.value = value;
     done = true;
+    this.notify();
   }
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
@@ -453,14 +453,15 @@ public class BaseExecutor {
       // Use an arbitrary timeout to relax cpu usage.
       waitTimeout = Math.min(maxDurationNs / 10, 10000000 /* 1ms*/);
     }
-    while (RCLJava.ok() && maxDurationNotElapsed(maxDurationNs, startNs)) {
+    while (RCLJava.ok() && (maxDurationNs  < 0 || maxDurationNotElapsed(maxDurationNs, startNs))) {
       waitForWork(waitTimeout);
       AnyExecutable anyExecutable = getNextExecutable();
-      if (anyExecutable != null) {
+      while (anyExecutable != null) {
         executeAnyExecutable(anyExecutable);
-      }
-      if (future.isDone()) {
-        break;
+        if (future.isDone()) {
+          return;
+        }
+        anyExecutable = getNextExecutable();
       }
     }
   }

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
@@ -17,7 +17,6 @@ package org.ros2.rcljava.executors;
 
 import java.lang.Math;
 import java.lang.SuppressWarnings;
-import java.util.concurrent.Future;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/Executor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/Executor.java
@@ -15,6 +15,8 @@
 
 package org.ros2.rcljava.executors;
 
+import java.util.concurrent.Future;
+
 import org.ros2.rcljava.node.ComposableNode;
 
 public interface Executor {
@@ -25,6 +27,10 @@ public interface Executor {
   public void spinOnce();
 
   public void spinOnce(long timeout);
+
+  public void spinUntilComplete(Future future, long maxDurationNs);
+
+  public void spinUntilComplete(Future future);
 
   public void spinSome();
 

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java
@@ -17,6 +17,7 @@ package org.ros2.rcljava.executors;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.node.ComposableNode;
@@ -53,6 +54,14 @@ public class MultiThreadedExecutor implements Executor {
 
   public void spinOnce(long timeout) {
     this.baseExecutor.spinOnce(timeout);
+  }
+
+  public void spinUntilComplete(Future future, long timeoutNs) {
+    this.baseExecutor.spinUntilComplete(future, timeoutNs);
+  }
+
+  public void spinUntilComplete(Future future) {
+    this.baseExecutor.spinUntilComplete(future, -1);
   }
 
   public void spinSome() {

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/SingleThreadedExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/SingleThreadedExecutor.java
@@ -15,6 +15,8 @@
 
 package org.ros2.rcljava.executors;
 
+import java.util.concurrent.Future;
+
 import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.node.ComposableNode;
 import org.ros2.rcljava.executors.BaseExecutor;
@@ -36,6 +38,14 @@ public class SingleThreadedExecutor implements Executor {
 
   public void spinOnce(long timeout) {
     this.baseExecutor.spinOnce(timeout);
+  }
+
+  public void spinUntilComplete(Future future, long timeoutNs) {
+    this.baseExecutor.spinUntilComplete(future, timeoutNs);
+  }
+
+  public void spinUntilComplete(Future future) {
+    this.baseExecutor.spinUntilComplete(future, -1);
   }
 
   public void spinSome() {

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClient.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClient.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.Future;
 
 import org.ros2.rcljava.consumers.Consumer;
+import org.ros2.rcljava.node.Node;
 import org.ros2.rcljava.parameters.ParameterType;
 import org.ros2.rcljava.parameters.ParameterVariant;
 
@@ -59,4 +60,6 @@ public interface AsyncParametersClient {
   public Future<List<rcl_interfaces.msg.ParameterDescriptor>> describeParameters(
       final List<String> names,
       final Consumer<Future<List<rcl_interfaces.msg.ParameterDescriptor>>> callback);
+
+  public Node getNode();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -309,4 +309,8 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
         });
     return futureResult;
   }
+
+  public Node getNode() {
+    return this.node;
+  }
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -188,7 +188,6 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
       requestParameters.add(parameterVariant.toParameter());
     }
     request.setParameters(requestParameters);
-
     setParametersClient.asyncSendRequest(
         request, new Consumer<Future<rcl_interfaces.srv.SetParameters_Response>>() {
           public void accept(final Future<rcl_interfaces.srv.SetParameters_Response> future) {

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -104,8 +104,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
 
   public Future<List<ParameterVariant>> getParameters(
       final List<String> names, final Consumer<Future<List<ParameterVariant>>> callback) {
-    final RCLFuture<List<ParameterVariant>> futureResult =
-        new RCLFuture<List<ParameterVariant>>(new WeakReference<Node>(this.node));
+    final RCLFuture<List<ParameterVariant>> futureResult = new RCLFuture<List<ParameterVariant>>();
     final rcl_interfaces.srv.GetParameters_Request request =
         new rcl_interfaces.srv.GetParameters_Request();
     request.setNames(names);
@@ -141,8 +140,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
 
   public Future<List<ParameterType>> getParameterTypes(
       final List<String> names, final Consumer<Future<List<ParameterType>>> callback) {
-    final RCLFuture<List<ParameterType>> futureResult =
-        new RCLFuture<List<ParameterType>>(new WeakReference<Node>(this.node));
+    final RCLFuture<List<ParameterType>> futureResult = new RCLFuture<List<ParameterType>>();
     final rcl_interfaces.srv.GetParameterTypes_Request request =
         new rcl_interfaces.srv.GetParameterTypes_Request();
     request.setNames(names);
@@ -215,7 +213,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
       final List<ParameterVariant> parameters,
       final Consumer<Future<rcl_interfaces.msg.SetParametersResult>> callback) {
     final RCLFuture<rcl_interfaces.msg.SetParametersResult> futureResult =
-        new RCLFuture<rcl_interfaces.msg.SetParametersResult>(new WeakReference<Node>(this.node));
+        new RCLFuture<rcl_interfaces.msg.SetParametersResult>();
     final rcl_interfaces.srv.SetParametersAtomically_Request request =
         new rcl_interfaces.srv.SetParametersAtomically_Request();
     List<rcl_interfaces.msg.Parameter> requestParameters =
@@ -252,7 +250,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
   public Future<rcl_interfaces.msg.ListParametersResult> listParameters(final List<String> prefixes,
       long depth, final Consumer<Future<rcl_interfaces.msg.ListParametersResult>> callback) {
     final RCLFuture<rcl_interfaces.msg.ListParametersResult> futureResult =
-        new RCLFuture<rcl_interfaces.msg.ListParametersResult>(new WeakReference<Node>(this.node));
+        new RCLFuture<rcl_interfaces.msg.ListParametersResult>();
     final rcl_interfaces.srv.ListParameters_Request request =
         new rcl_interfaces.srv.ListParameters_Request();
     request.setPrefixes(prefixes);

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.client.Client;
 import org.ros2.rcljava.concurrent.RCLFuture;
 import org.ros2.rcljava.consumers.Consumer;
@@ -33,24 +34,6 @@ import org.ros2.rcljava.parameters.ParameterType;
 import org.ros2.rcljava.parameters.ParameterVariant;
 
 public class SyncParametersClientImpl implements SyncParametersClient {
-  private static class ConsumerHelper<T> implements Consumer<Future<T>> {
-    private RCLFuture<T> resultFuture;
-
-    public void accept(final Future<T> future) {
-      T result = null;
-      try {
-        result = future.get();
-      } catch (Exception e) {
-        // TODO(esteve): do something
-      }
-      this.resultFuture.set(result);
-    }
-
-    public ConsumerHelper(RCLFuture<T> resultFuture) {
-      this.resultFuture = resultFuture;
-    }
-  }
-
   private Executor executor;
 
   public AsyncParametersClient asyncParametersClient;
@@ -107,79 +90,54 @@ public class SyncParametersClientImpl implements SyncParametersClient {
     this(executor, node, "", QoSProfile.PARAMETERS);
   }
 
+  private <T> T spinUntilComplete(Future<T> future)
+    throws InterruptedException, ExecutionException
+  {
+    if (executor != null) {
+      executor.spinUntilComplete(future);
+    } else {
+      RCLJava.spinUntilComplete(this.asyncParametersClient.getNode(), future);
+    }
+    return future.get();
+  }
+
   public List<ParameterVariant> getParameters(final List<String> names)
       throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<ParameterVariant>> future = new RCLFuture<List<ParameterVariant>>(executor);
-      asyncParametersClient.getParameters(
-          names, new ConsumerHelper<List<ParameterVariant>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.getParameters(names, null).get();
-    }
+    Future<List<ParameterVariant>> future = asyncParametersClient.getParameters(names, null);
+    return spinUntilComplete(future);
   }
 
   public List<ParameterType> getParameterTypes(final List<String> names)
       throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<ParameterType>> future = new RCLFuture<List<ParameterType>>(executor);
-      asyncParametersClient.getParameterTypes(
-          names, new ConsumerHelper<List<ParameterType>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.getParameterTypes(names, null).get();
-    }
+    Future<List<ParameterType>> future = asyncParametersClient.getParameterTypes(names, null);
+    return spinUntilComplete(future);
   }
 
   public List<rcl_interfaces.msg.SetParametersResult> setParameters(
       final List<ParameterVariant> parameters) throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<rcl_interfaces.msg.SetParametersResult>> future =
-          new RCLFuture<List<rcl_interfaces.msg.SetParametersResult>>(executor);
-      asyncParametersClient.setParameters(
-          parameters, new ConsumerHelper<List<rcl_interfaces.msg.SetParametersResult>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.setParameters(parameters, null).get();
-    }
+    Future<List<rcl_interfaces.msg.SetParametersResult>> future = asyncParametersClient.setParameters(
+      parameters, null);
+    return spinUntilComplete(future);
   }
 
   public rcl_interfaces.msg.SetParametersResult setParametersAtomically(
       final List<ParameterVariant> parameters) throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<rcl_interfaces.msg.SetParametersResult> future =
-          new RCLFuture<rcl_interfaces.msg.SetParametersResult>(executor);
-      asyncParametersClient.setParametersAtomically(
-          parameters, new ConsumerHelper<rcl_interfaces.msg.SetParametersResult>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.setParametersAtomically(parameters, null).get();
-    }
+    Future<rcl_interfaces.msg.SetParametersResult> future = asyncParametersClient.setParametersAtomically(
+      parameters, null);
+    return spinUntilComplete(future);
   }
 
   public rcl_interfaces.msg.ListParametersResult listParameters(
       final List<String> prefixes, long depth) throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<rcl_interfaces.msg.ListParametersResult> future =
-          new RCLFuture<rcl_interfaces.msg.ListParametersResult>(executor);
-      asyncParametersClient.listParameters(
-          prefixes, depth, new ConsumerHelper<rcl_interfaces.msg.ListParametersResult>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.listParameters(prefixes, depth, null).get();
-    }
+    Future<rcl_interfaces.msg.ListParametersResult> future = asyncParametersClient.listParameters(
+      prefixes, depth, null);
+    return spinUntilComplete(future);
   }
 
   public List<rcl_interfaces.msg.ParameterDescriptor> describeParameters(final List<String> names)
       throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>> future =
-          new RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>>(executor);
-      asyncParametersClient.describeParameters(
-          names, new ConsumerHelper<List<rcl_interfaces.msg.ParameterDescriptor>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.describeParameters(names, null).get();
-    }
+    Future<List<rcl_interfaces.msg.ParameterDescriptor>> future = asyncParametersClient.describeParameters(
+      names, null);
+    return spinUntilComplete(future);
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/action/ActionServerTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/action/ActionServerTest.java
@@ -139,19 +139,9 @@ public class ActionServerTest {
     Future<test_msgs.action.Fibonacci_SendGoal_Response> future =
       this.mockActionClient.sendGoalClient.asyncSendRequest(request);
 
-    test_msgs.action.Fibonacci_SendGoal_Response response = null;
     long startTime = System.nanoTime();
-    while (RCLJava.ok() && !future.isDone()) {
-      this.executor.spinOnce(1);
-      response = future.get(100, TimeUnit.MILLISECONDS);
-
-      // Check for timeout
-      long duration = System.nanoTime() - startTime;
-      if (TimeUnit.NANOSECONDS.toSeconds(duration) >= 5) {
-        break;
-      }
-    }
-    return response;
+    this.executor.spinUntilComplete(future, TimeUnit.SECONDS.toNanos(5));
+    return future.get();
   }
 
   @Test
@@ -211,15 +201,7 @@ public class ActionServerTest {
 
     // Wait for cancel response
     long startTime = System.nanoTime();
-    while (RCLJava.ok() && !cancelResponseFuture.isDone()) {
-      this.executor.spinOnce(100000000);  // timeout of 100 milliseconds
-
-      // Check for timeout
-      long duration = System.nanoTime() - startTime;
-      if (TimeUnit.NANOSECONDS.toSeconds(duration) >= 5) {
-        break;
-      }
-    }
+    this.executor.spinUntilComplete(cancelResponseFuture, TimeUnit.SECONDS.toNanos(5));
 
     assertEquals(true, cancelResponseFuture.isDone());
     action_msgs.srv.CancelGoal_Response cancelResponse = cancelResponseFuture.get();

--- a/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
@@ -74,7 +74,6 @@ public class ClientTest {
     public final void accept(final RMWRequestId header,
         final rcljava.srv.AddTwoInts_Request request,
         final rcljava.srv.AddTwoInts_Response response) {
-      System.err.println("accept() called");
       if (!this.future.isDone()) {
         response.setSum(request.getA() + request.getB());
         this.future.set(response);
@@ -116,14 +115,10 @@ public class ClientTest {
 
     assertTrue(client.waitForService(Duration.ofSeconds(10)));
 
-    System.err.println("sending async request");
     Future<rcljava.srv.AddTwoInts_Response> responseFuture = client.asyncSendRequest(request);
 
-    System.err.println("spinning until complete");
     RCLJava.spinUntilComplete(node, responseFuture, TimeUnit.SECONDS.toNanos(10));
-    System.err.println("spinning until complete finished -- getting future");
     rcljava.srv.AddTwoInts_Response response = responseFuture.get();
-    System.err.println("got future");
 
     // Check that the message was received by the service
     assertTrue(consumerFuture.isDone());

--- a/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.lang.System;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.time.Duration;

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -226,7 +226,7 @@ public class NodeTest {
         node.<std_msgs.msg.String>createPublisher(std_msgs.msg.String.class, "test_topic_string");
 
     RCLFuture<std_msgs.msg.String> future =
-        new RCLFuture<std_msgs.msg.String>(new WeakReference<Node>(node));
+        new RCLFuture<std_msgs.msg.String>();
 
     Subscription<std_msgs.msg.String> subscription =
         node.<std_msgs.msg.String>createSubscription(std_msgs.msg.String.class, "test_topic_string",
@@ -256,7 +256,7 @@ public class NodeTest {
             rcljava.msg.BoundedArrayNested.class, "test_topic_bounded_array_nested");
 
     RCLFuture<rcljava.msg.BoundedArrayNested> future =
-        new RCLFuture<rcljava.msg.BoundedArrayNested>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.BoundedArrayNested>();
 
     Subscription<rcljava.msg.BoundedArrayNested> subscription =
         node.<rcljava.msg.BoundedArrayNested>createSubscription(
@@ -298,7 +298,7 @@ public class NodeTest {
             rcljava.msg.BoundedArrayPrimitives.class, "test_topic_bounded_array_primitives");
 
     RCLFuture<rcljava.msg.BoundedArrayPrimitives> future =
-        new RCLFuture<rcljava.msg.BoundedArrayPrimitives>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.BoundedArrayPrimitives>();
 
     Subscription<rcljava.msg.BoundedArrayPrimitives> subscription =
         node.<rcljava.msg.BoundedArrayPrimitives>createSubscription(
@@ -371,7 +371,7 @@ public class NodeTest {
         rcljava.msg.Builtins.class, "test_topic_builtins");
 
     RCLFuture<rcljava.msg.Builtins> future =
-        new RCLFuture<rcljava.msg.Builtins>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.Builtins>();
 
     Subscription<rcljava.msg.Builtins> subscription =
         node.<rcljava.msg.Builtins>createSubscription(rcljava.msg.Builtins.class,
@@ -418,7 +418,7 @@ public class NodeTest {
             rcljava.msg.DynamicArrayNested.class, "test_topic_dynamic_array_nested");
 
     RCLFuture<rcljava.msg.DynamicArrayNested> future =
-        new RCLFuture<rcljava.msg.DynamicArrayNested>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.DynamicArrayNested>();
 
     Subscription<rcljava.msg.DynamicArrayNested> subscription =
         node.<rcljava.msg.DynamicArrayNested>createSubscription(
@@ -460,7 +460,7 @@ public class NodeTest {
             rcljava.msg.DynamicArrayPrimitives.class, "test_topic_dynamic_array_primitives");
 
     RCLFuture<rcljava.msg.DynamicArrayPrimitives> future =
-        new RCLFuture<rcljava.msg.DynamicArrayPrimitives>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.DynamicArrayPrimitives>();
 
     Subscription<rcljava.msg.DynamicArrayPrimitives> subscription =
         node.<rcljava.msg.DynamicArrayPrimitives>createSubscription(
@@ -533,7 +533,7 @@ public class NodeTest {
         node.<rcljava.msg.Empty>createPublisher(rcljava.msg.Empty.class, "test_topic_empty");
 
     RCLFuture<rcljava.msg.Empty> future =
-        new RCLFuture<rcljava.msg.Empty>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.Empty>();
 
     Subscription<rcljava.msg.Empty> subscription = node.<rcljava.msg.Empty>createSubscription(
         rcljava.msg.Empty.class, "test_topic_empty", new TestConsumer<rcljava.msg.Empty>(future));
@@ -561,7 +561,7 @@ public class NodeTest {
             rcljava.msg.FieldsWithSameType.class, "test_topic_fields_with_same_type");
 
     RCLFuture<rcljava.msg.FieldsWithSameType> future =
-        new RCLFuture<rcljava.msg.FieldsWithSameType>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.FieldsWithSameType>();
 
     Subscription<rcljava.msg.FieldsWithSameType> subscription =
         node.<rcljava.msg.FieldsWithSameType>createSubscription(
@@ -605,7 +605,7 @@ public class NodeTest {
         node.<rcljava.msg.Nested>createPublisher(rcljava.msg.Nested.class, "test_topic_nested");
 
     RCLFuture<rcljava.msg.Nested> future =
-        new RCLFuture<rcljava.msg.Nested>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.Nested>();
 
     Subscription<rcljava.msg.Nested> subscription =
         node.<rcljava.msg.Nested>createSubscription(rcljava.msg.Nested.class, "test_topic_nested",
@@ -640,7 +640,7 @@ public class NodeTest {
         rcljava.msg.Primitives.class, "test_topic_primitives");
 
     RCLFuture<rcljava.msg.Primitives> future =
-        new RCLFuture<rcljava.msg.Primitives>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.Primitives>();
 
     Subscription<rcljava.msg.Primitives> subscription =
         node.<rcljava.msg.Primitives>createSubscription(rcljava.msg.Primitives.class,
@@ -671,7 +671,7 @@ public class NodeTest {
             rcljava.msg.StaticArrayNested.class, "test_topic_static_array_nested");
 
     RCLFuture<rcljava.msg.StaticArrayNested> future =
-        new RCLFuture<rcljava.msg.StaticArrayNested>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.StaticArrayNested>();
 
     Subscription<rcljava.msg.StaticArrayNested> subscription =
         node.<rcljava.msg.StaticArrayNested>createSubscription(rcljava.msg.StaticArrayNested.class,
@@ -726,7 +726,7 @@ public class NodeTest {
             rcljava.msg.StaticArrayPrimitives.class, "test_topic_static_array_primitives");
 
     RCLFuture<rcljava.msg.StaticArrayPrimitives> future =
-        new RCLFuture<rcljava.msg.StaticArrayPrimitives>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.StaticArrayPrimitives>();
 
     Subscription<rcljava.msg.StaticArrayPrimitives> subscription =
         node.<rcljava.msg.StaticArrayPrimitives>createSubscription(
@@ -800,7 +800,7 @@ public class NodeTest {
         node.<rcljava.msg.UInt32>createPublisher(rcljava.msg.UInt32.class, "test_topic_uint32");
 
     RCLFuture<rcljava.msg.UInt32> future =
-        new RCLFuture<rcljava.msg.UInt32>(new WeakReference<Node>(node));
+        new RCLFuture<rcljava.msg.UInt32>();
 
     Subscription<rcljava.msg.UInt32> subscription =
         node.<rcljava.msg.UInt32>createSubscription(rcljava.msg.UInt32.class, "test_topic_uint32",
@@ -834,13 +834,13 @@ public class NodeTest {
     Publisher<rcljava.msg.UInt32> publisher = publisherNode.<rcljava.msg.UInt32>createPublisher(
         rcljava.msg.UInt32.class, "test_topic_multiple");
 
-    RCLFuture<rcljava.msg.UInt32> futureOne = new RCLFuture<rcljava.msg.UInt32>(executor);
+    RCLFuture<rcljava.msg.UInt32> futureOne = new RCLFuture<rcljava.msg.UInt32>();
 
     Subscription<rcljava.msg.UInt32> subscriptionOne =
         subscriptionNodeOne.<rcljava.msg.UInt32>createSubscription(rcljava.msg.UInt32.class,
             "test_topic_multiple", new TestConsumer<rcljava.msg.UInt32>(futureOne));
 
-    RCLFuture<rcljava.msg.UInt32> futureTwo = new RCLFuture<rcljava.msg.UInt32>(executor);
+    RCLFuture<rcljava.msg.UInt32> futureTwo = new RCLFuture<rcljava.msg.UInt32>();
 
     Subscription<rcljava.msg.UInt32> subscriptionTwo =
         subscriptionNodeTwo.<rcljava.msg.UInt32>createSubscription(rcljava.msg.UInt32.class,

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -28,12 +28,14 @@ import org.junit.Test;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
+import java.lang.System;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.ros2.rcljava.RCLJava;
 import org.ros2.rcljava.concurrent.RCLFuture;

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
-import java.lang.System;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -113,19 +113,18 @@ public class AsyncParametersClientTest {
         new ParameterVariant("foo.second", 42), new ParameterVariant("foobar", true)});
 
     RCLFuture<List<rcl_interfaces.msg.SetParametersResult>> future =
-        new RCLFuture<List<rcl_interfaces.msg.SetParametersResult>>(
-            new WeakReference<Node>(this.node));
+        new RCLFuture<List<rcl_interfaces.msg.SetParametersResult>>();
     parametersClient.setParameters(parameters, new TestConsumer(future));
 
-    List<String> parameterNames =
-        Arrays.asList(new String[] {"foo", "bar", "baz", "foo.first", "foo.second", "foobar"});
-
+    RCLJava.spinUntilComplete(node, future);
     List<rcl_interfaces.msg.SetParametersResult> setParametersResults = future.get();
     assertEquals(6, setParametersResults.size());
     for (rcl_interfaces.msg.SetParametersResult result : setParametersResults) {
       assertEquals(true, result.getSuccessful());
     }
 
+    List<String> parameterNames =
+      Arrays.asList(new String[] {"foo", "bar", "baz", "foo.first", "foo.second", "foobar"});
     List<ParameterVariant> results = node.getParameters(parameterNames);
     assertEquals(parameters, results);
   }
@@ -142,10 +141,10 @@ public class AsyncParametersClientTest {
     List<String> parameterNames =
         Arrays.asList(new String[] {"foo", "bar", "baz", "foo.first", "foo.second", "foobar"});
 
-    RCLFuture<List<ParameterVariant>> future =
-        new RCLFuture<List<ParameterVariant>>(new WeakReference<Node>(this.node));
+    RCLFuture<List<ParameterVariant>> future = new RCLFuture<List<ParameterVariant>>();
     parametersClient.getParameters(parameterNames, new TestConsumer(future));
 
+    RCLJava.spinUntilComplete(node, future);
     assertEquals(parameters, future.get());
   }
 
@@ -159,10 +158,11 @@ public class AsyncParametersClientTest {
     node.setParameters(parameters);
 
     RCLFuture<rcl_interfaces.msg.ListParametersResult> future =
-        new RCLFuture<rcl_interfaces.msg.ListParametersResult>(new WeakReference<Node>(this.node));
+        new RCLFuture<rcl_interfaces.msg.ListParametersResult>();
     parametersClient.listParameters(
         Arrays.asList(new String[] {"foo", "bar"}), 10, new TestConsumer(future));
 
+    RCLJava.spinUntilComplete(node, future);
     assertArrayEquals(new String[] {"foo.first", "foo.second"}, future.get().getNames());
     assertArrayEquals(new String[] {"foo"}, future.get().getPrefixes());
   }
@@ -177,8 +177,7 @@ public class AsyncParametersClientTest {
     node.setParameters(parameters);
 
     RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>> future =
-        new RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>>(
-            new WeakReference<Node>(this.node));
+        new RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>>();
     parametersClient.describeParameters(
         Arrays.asList(new String[] {"foo", "bar"}), new TestConsumer(future));
 
@@ -188,6 +187,7 @@ public class AsyncParametersClientTest {
                 rcl_interfaces.msg.ParameterType.PARAMETER_INTEGER),
             new rcl_interfaces.msg.ParameterDescriptor().setName("bar").setType(
                 rcl_interfaces.msg.ParameterType.PARAMETER_STRING)});
+    RCLJava.spinUntilComplete(node, future);
     assertEquals(expected, future.get());
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/timer/TimerTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/timer/TimerTest.java
@@ -75,7 +75,7 @@ public class TimerTest {
     int max_iterations = 4;
 
     Node node = RCLJava.createNode("test_timer_node");
-    RCLFuture<Boolean> future = new RCLFuture<Boolean>(new WeakReference<Node>(node));
+    RCLFuture<Boolean> future = new RCLFuture<Boolean>();
     TimerCallback timerCallback = new TimerCallback(future, max_iterations);
     Timer timer = node.createWallTimer(250, TimeUnit.MILLISECONDS, timerCallback);
     assertNotEquals(0, timer.getHandle());
@@ -83,6 +83,7 @@ public class TimerTest {
     assertEquals(
         TimeUnit.NANOSECONDS.convert(250, TimeUnit.MILLISECONDS), timer.getTimerPeriodNS());
 
+    RCLJava.spinUntilComplete(node, future);
     boolean result = future.get(3, TimeUnit.SECONDS);
     assertTrue(result);
     assertEquals(4, timerCallback.getCounter());
@@ -97,7 +98,7 @@ public class TimerTest {
     int max_iterations = 4;
 
     Node node = RCLJava.createNode("test_timer_node");
-    RCLFuture<Boolean> future = new RCLFuture<Boolean>(new WeakReference<Node>(node));
+    RCLFuture<Boolean> future = new RCLFuture<Boolean>();
     TimerCallback timerCallback = new TimerCallback(future, max_iterations);
     Timer timer = node.createTimer(250, TimeUnit.MILLISECONDS, timerCallback);
     assertNotEquals(0, timer.getHandle());
@@ -105,6 +106,7 @@ public class TimerTest {
     assertEquals(
         TimeUnit.NANOSECONDS.convert(250, TimeUnit.MILLISECONDS), timer.getTimerPeriodNS());
 
+    RCLJava.spinUntilComplete(node, future);
     boolean result = future.get(3, TimeUnit.SECONDS);
     assertTrue(result);
     assertEquals(4, timerCallback.getCounter());


### PR DESCRIPTION
Don't use `spin()` in `RCLFuture.get()`.
The problem with that is that you cannot currently call `spin()` more than once, so that model is really limited.

This uses a model more similar to the one in `rclcpp`.
You can block on a future while spinning in another thread, or use `Executor.spinUntilComplete()`.

That model is still somewhat limited, but a bit better.

Note: this may break prexisting code that were calling `Future.get()` without spinning.